### PR TITLE
Fix parsing regexes and sanitizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.gradle/
+build/

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,8 @@ version = '0.2.0'
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        // Use the available JDK to compile the project
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ version = '0.2.0'
 
 java {
     toolchain {
+        // Use the available JDK to compile the project
         languageVersion = JavaLanguageVersion.of(21)
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ version = '0.2.0'
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 

--- a/src/main/java/com/example/agent/bootstrap/Improver.java
+++ b/src/main/java/com/example/agent/bootstrap/Improver.java
@@ -33,19 +33,19 @@ public class Improver {
             line = line.trim();
             if (line.isEmpty()) continue;
             try {
-                String id = extract(line, ""id"\s*:\s*"(.*?)"");
-                String irType = extract(line, ""irType"\s*:\s*"(.*?)"");
-                String regex = extract(line, ""regex"\s*:\s*"(.*?)"");
-                String fields = extract(line, ""fields"\s*:\s*\[(.*?)\]");
-                String listFields = extract(line, ""listFields"\s*:\s*\[(.*?)\]");
-                String tpl = extract(line, ""javaTemplate"\s*:\s*"(.*?)"");
+                String id = extract(line, "\"id\"\\s*:\\s*\"(.*?)\"");
+                String irType = extract(line, "\"irType\"\\s*:\\s*\"(.*?)\"");
+                String regex = extract(line, "\"regex\"\\s*:\\s*\"(.*?)\"");
+                String fields = extract(line, "\"fields\"\\s*:\\s*\\[(.*?)\\]");
+                String listFields = extract(line, "\"listFields\"\\s*:\\s*\\[(.*?)\\]");
+                String tpl = extract(line, "\"javaTemplate\"\\s*:\\s*\"(.*?)\"");
                 if (id == null || irType == null || regex == null || fields == null) continue;
                 var fs = new java.util.ArrayList<String>();
-                var m1 = java.util.regex.Pattern.compile(""(.*?)"").matcher(fields);
+                var m1 = java.util.regex.Pattern.compile("\"(.*?)\"").matcher(fields);
                 while (m1.find()) fs.add(m1.group(1));
                 var lfs = new java.util.ArrayList<String>();
                 if (listFields != null) {
-                    var m2 = java.util.regex.Pattern.compile(""(.*?)"").matcher(listFields);
+                    var m2 = java.util.regex.Pattern.compile("\"(.*?)\"").matcher(listFields);
                     while (m2.find()) lfs.add(m2.group(1));
                 }
                 store.addOrUpdateRule(new Rule(id, irType, regex, fs.toArray(new String[0]), lfs.toArray(new String[0]), tpl));

--- a/src/main/java/com/example/agent/bootstrap/Improver.java
+++ b/src/main/java/com/example/agent/bootstrap/Improver.java
@@ -8,6 +8,10 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Generates improvement suggestions for parsing rules based on
+ * a dialect snippet and the resulting Java code.
+ */
 public class Improver {
 
     private final GigaChatOpenAIClient llm;
@@ -18,38 +22,60 @@ public class Improver {
         this.store = store;
     }
 
+    /**
+     * Ask the LLM for rule refinements and merge them into the rule store.
+     */
     public void refineRules(String dialectSnippet, String javaResult, String diagnosticsOrFeedback) throws IOException {
-        String prompt = "На основе пары (диалект -> Java) предложи улучшения правил распознавания в формате JSONL. " +
+        String prompt =
+                "На основе пары (диалект -> Java) предложи улучшения правил распознавания в формате JSONL. " +
                 "Строгие поля: id, irType, regex, fields:[...], listFields:[...] (опц.), javaTemplate (опц.). " +
                 "Используй IR-ноды: Assign(name,expr), Call(callee,args), Decl(name,type), If(cond), Loop(header). " +
                 "Не дублируй существующие правила, обобщи, стабилизируй regex.\n\n" +
-                "Диалект:\n" + dialectSnippet + "\n\nJava:\n" + javaResult + "\n\nЗамечания/диагностика:\n" + diagnosticsOrFeedback +
+                "Диалект:\n" + dialectSnippet + "\n\nJava:\n" + javaResult +
+                "\n\nЗамечания/диагностика:\n" + diagnosticsOrFeedback +
                 "\n\nВерни только JSONL.";
-        String jsonl = llm.chat(List.of(
-                Map.of("role","system","content","Возвращай только JSONL, по одному объекту в строке."),
-                Map.of("role","user","content", prompt)
-        ), 0.2);
-        for (String line : jsonl.split("\r?\n")) {
+
+        String jsonl = llm.chat(
+                List.of(
+                        Map.of("role", "system", "content", "Возвращай только JSONL, по одному объекту в строке."),
+                        Map.of("role", "user", "content", prompt)
+                ),
+                0.2
+        );
+
+        for (String line : jsonl.split("\\r?\\n")) {
             line = line.trim();
             if (line.isEmpty()) continue;
             try {
-                String id = extract(line, ""id"\s*:\s*"(.*?)"");
-                String irType = extract(line, ""irType"\s*:\s*"(.*?)"");
-                String regex = extract(line, ""regex"\s*:\s*"(.*?)"");
-                String fields = extract(line, ""fields"\s*:\s*\[(.*?)\]");
-                String listFields = extract(line, ""listFields"\s*:\s*\[(.*?)\]");
-                String tpl = extract(line, ""javaTemplate"\s*:\s*"(.*?)"");
+                String id = extract(line, "\\\"id\\\"\\s*:\\s*\\\"(.*?)\\\"");
+                String irType = extract(line, "\\\"irType\\\"\\s*:\\s*\\\"(.*?)\\\"");
+                String regex = extract(line, "\\\"regex\\\"\\s*:\\s*\\\"(.*?)\\\"");
+                String fields = extract(line, "\\\"fields\\\"\\s*:\\s*\\[(.*?)\\]");
+                String listFields = extract(line, "\\\"listFields\\\"\\s*:\\s*\\[(.*?)\\]");
+                String tpl = extract(line, "\\\"javaTemplate\\\"\\s*:\\s*\\\"(.*?)\\\"");
                 if (id == null || irType == null || regex == null || fields == null) continue;
+
                 var fs = new java.util.ArrayList<String>();
-                var m1 = java.util.regex.Pattern.compile(""(.*?)"").matcher(fields);
+                var m1 = java.util.regex.Pattern.compile("\\\"(.*?)\\\"").matcher(fields);
                 while (m1.find()) fs.add(m1.group(1));
+
                 var lfs = new java.util.ArrayList<String>();
                 if (listFields != null) {
-                    var m2 = java.util.regex.Pattern.compile(""(.*?)"").matcher(listFields);
+                    var m2 = java.util.regex.Pattern.compile("\\\"(.*?)\\\"").matcher(listFields);
                     while (m2.find()) lfs.add(m2.group(1));
                 }
-                store.addOrUpdateRule(new Rule(id, irType, regex, fs.toArray(new String[0]), lfs.toArray(new String[0]), tpl));
-            } catch (Exception ignored) {}
+
+                store.addOrUpdateRule(new Rule(
+                        id,
+                        irType,
+                        regex,
+                        fs.toArray(new String[0]),
+                        lfs.toArray(new String[0]),
+                        tpl
+                ));
+            } catch (Exception ignored) {
+                // Skip malformed lines silently
+            }
         }
     }
 
@@ -58,3 +84,4 @@ public class Improver {
         return m.find() ? m.group(1) : null;
     }
 }
+

--- a/src/main/java/com/example/agent/bootstrap/Improver.java
+++ b/src/main/java/com/example/agent/bootstrap/Improver.java
@@ -22,60 +22,38 @@ public class Improver {
         this.store = store;
     }
 
-    /**
-     * Ask the LLM for rule refinements and merge them into the rule store.
-     */
     public void refineRules(String dialectSnippet, String javaResult, String diagnosticsOrFeedback) throws IOException {
-        String prompt =
-                "На основе пары (диалект -> Java) предложи улучшения правил распознавания в формате JSONL. " +
+        String prompt = "На основе пары (диалект -> Java) предложи улучшения правил распознавания в формате JSONL. " +
                 "Строгие поля: id, irType, regex, fields:[...], listFields:[...] (опц.), javaTemplate (опц.). " +
                 "Используй IR-ноды: Assign(name,expr), Call(callee,args), Decl(name,type), If(cond), Loop(header). " +
                 "Не дублируй существующие правила, обобщи, стабилизируй regex.\n\n" +
-                "Диалект:\n" + dialectSnippet + "\n\nJava:\n" + javaResult +
-                "\n\nЗамечания/диагностика:\n" + diagnosticsOrFeedback +
+                "Диалект:\n" + dialectSnippet + "\n\nJava:\n" + javaResult + "\n\nЗамечания/диагностика:\n" + diagnosticsOrFeedback +
                 "\n\nВерни только JSONL.";
-
-        String jsonl = llm.chat(
-                List.of(
-                        Map.of("role", "system", "content", "Возвращай только JSONL, по одному объекту в строке."),
-                        Map.of("role", "user", "content", prompt)
-                ),
-                0.2
-        );
-
-        for (String line : jsonl.split("\\r?\\n")) {
+        String jsonl = llm.chat(List.of(
+                Map.of("role","system","content","Возвращай только JSONL, по одному объекту в строке."),
+                Map.of("role","user","content", prompt)
+        ), 0.2);
+        for (String line : jsonl.split("\r?\n")) {
             line = line.trim();
             if (line.isEmpty()) continue;
             try {
-                String id = extract(line, "\\\"id\\\"\\s*:\\s*\\\"(.*?)\\\"");
-                String irType = extract(line, "\\\"irType\\\"\\s*:\\s*\\\"(.*?)\\\"");
-                String regex = extract(line, "\\\"regex\\\"\\s*:\\s*\\\"(.*?)\\\"");
-                String fields = extract(line, "\\\"fields\\\"\\s*:\\s*\\[(.*?)\\]");
-                String listFields = extract(line, "\\\"listFields\\\"\\s*:\\s*\\[(.*?)\\]");
-                String tpl = extract(line, "\\\"javaTemplate\\\"\\s*:\\s*\\\"(.*?)\\\"");
+                String id = extract(line, "\"id\"\\s*:\\s*\"(.*?)\"");
+                String irType = extract(line, "\"irType\"\\s*:\\s*\"(.*?)\"");
+                String regex = extract(line, "\"regex\"\\s*:\\s*\"(.*?)\"");
+                String fields = extract(line, "\"fields\"\\s*:\\s*\\[(.*?)\\]");
+                String listFields = extract(line, "\"listFields\"\\s*:\\s*\\[(.*?)\\]");
+                String tpl = extract(line, "\"javaTemplate\"\\s*:\\s*\"(.*?)\"");
                 if (id == null || irType == null || regex == null || fields == null) continue;
-
                 var fs = new java.util.ArrayList<String>();
-                var m1 = java.util.regex.Pattern.compile("\\\"(.*?)\\\"").matcher(fields);
+                var m1 = java.util.regex.Pattern.compile("\"(.*?)\"").matcher(fields);
                 while (m1.find()) fs.add(m1.group(1));
-
                 var lfs = new java.util.ArrayList<String>();
                 if (listFields != null) {
-                    var m2 = java.util.regex.Pattern.compile("\\\"(.*?)\\\"").matcher(listFields);
+                    var m2 = java.util.regex.Pattern.compile("\"(.*?)\"").matcher(listFields);
                     while (m2.find()) lfs.add(m2.group(1));
                 }
-
-                store.addOrUpdateRule(new Rule(
-                        id,
-                        irType,
-                        regex,
-                        fs.toArray(new String[0]),
-                        lfs.toArray(new String[0]),
-                        tpl
-                ));
-            } catch (Exception ignored) {
-                // Skip malformed lines silently
-            }
+                store.addOrUpdateRule(new Rule(id, irType, regex, fs.toArray(new String[0]), lfs.toArray(new String[0]), tpl));
+            } catch (Exception ignored) {}
         }
     }
 
@@ -84,4 +62,3 @@ public class Improver {
         return m.find() ? m.group(1) : null;
     }
 }
-

--- a/src/main/java/com/example/agent/bootstrap/Learner.java
+++ b/src/main/java/com/example/agent/bootstrap/Learner.java
@@ -55,19 +55,19 @@ public class Learner {
     }
 
     private Rule parseRule(String jsonLine) {
-        String id = extract(jsonLine, ""id"\s*:\s*"(.*?)"");
-        String irType = extract(jsonLine, ""irType"\s*:\s*"(.*?)"");
-        String regex = extract(jsonLine, ""regex"\s*:\s*"(.*?)"");
-        String fields = extract(jsonLine, ""fields"\s*:\s*\[(.*?)\]");
-        String listFields = extract(jsonLine, ""listFields"\s*:\s*\[(.*?)\]");
-        String tpl = extract(jsonLine, ""javaTemplate"\s*:\s*"(.*?)"");
+        String id = extract(jsonLine, "\"id\"\\s*:\\s*\"(.*?)\"");
+        String irType = extract(jsonLine, "\"irType\"\\s*:\\s*\"(.*?)\"");
+        String regex = extract(jsonLine, "\"regex\"\\s*:\\s*\"(.*?)\"");
+        String fields = extract(jsonLine, "\"fields\"\\s*:\\s*\\[(.*?)\\]");
+        String listFields = extract(jsonLine, "\"listFields\"\\s*:\\s*\\[(.*?)\\]");
+        String tpl = extract(jsonLine, "\"javaTemplate\"\\s*:\\s*\"(.*?)\"");
         if (id == null || irType == null || regex == null || fields == null) return null;
         java.util.List<String> fs = new java.util.ArrayList<>();
-        var m1 = java.util.regex.Pattern.compile(""(.*?)"").matcher(fields);
+        var m1 = java.util.regex.Pattern.compile("\"(.*?)\"").matcher(fields);
         while (m1.find()) fs.add(m1.group(1));
         java.util.List<String> lfs = new java.util.ArrayList<>();
         if (listFields != null) {
-            var m2 = java.util.regex.Pattern.compile(""(.*?)"").matcher(listFields);
+            var m2 = java.util.regex.Pattern.compile("\"(.*?)\"").matcher(listFields);
             while (m2.find()) lfs.add(m2.group(1));
         }
         return new Rule(id, irType, regex, fs.toArray(new String[0]), lfs.toArray(new String[0]), tpl);

--- a/src/main/java/com/example/agent/rag/SimpleIndexer.java
+++ b/src/main/java/com/example/agent/rag/SimpleIndexer.java
@@ -5,7 +5,7 @@ import java.util.regex.Pattern;
 
 /** Extremely simple in-memory TF-IDF index for code snippets. */
 public class SimpleIndexer {
-    private static final Pattern TOKEN = Pattern.compile("[A-Za-z_][A-Za-z0-9_]*|\S");
+    private static final Pattern TOKEN = Pattern.compile("[A-Za-z_][A-Za-z0-9_]*|\\S");
 
     private final List<String> docs = new ArrayList<>();
     private final List<Map<String, Integer>> termFreq = new ArrayList<>();

--- a/src/main/java/com/example/agent/translate/IRToJava.java
+++ b/src/main/java/com/example/agent/translate/IRToJava.java
@@ -40,7 +40,11 @@ public class IRToJava {
     }
 
     private String sanitize(String s) {
-        return s.replaceAll(":=|<>", "!=").replaceAll(" and ", " && ").replaceAll(" or ", " || ");
+        return s
+                .replace(":=", "=")
+                .replace("<>", "!=")
+                .replace(" and ", " && ")
+                .replace(" or ", " || ");
     }
 
     private String escape(String s) {


### PR DESCRIPTION
## Summary
- fix regex escaping when parsing JSONL rules in learner and improver
- correct IR sanitizer to handle assignment and comparison properly
- use available JDK 21 toolchain for building

## Testing
- `./gradlew test` *(fails: Could not resolve dependencies for configuration ':compileClasspath' (status code 403))*

------
https://chatgpt.com/codex/tasks/task_e_68c1e137db508320bd6045ede5d7e9c5