### PR TITLE
feat: add pluggable LLM providers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,4 +32,21 @@ application {
 
 tasks.withType(Test).configureEach {
     useJUnitPlatform()
+    def props = ['GIGACHAT_API_BASE','GIGACHAT_API_KEY','GIGACHAT_MODEL','LLM_PROVIDER',
+                 'GIGACHAT_CERT_FILE','GIGACHAT_KEY_FILE','GIGACHAT_CA_FILE']
+    props.each { p ->
+        if (project.hasProperty(p)) {
+            systemProperty p, project.property(p)
+        }
+    }
+}
+
+tasks.withType(JavaExec).configureEach {
+    def props = ['GIGACHAT_API_BASE','GIGACHAT_API_KEY','GIGACHAT_MODEL','LLM_PROVIDER',
+                 'GIGACHAT_CERT_FILE','GIGACHAT_KEY_FILE','GIGACHAT_CA_FILE']
+    props.each { p ->
+        if (project.hasProperty(p)) {
+            systemProperty p, project.property(p)
+        }
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,8 @@
 org.gradle.jvmargs=-Xmx1g -Dfile.encoding=UTF-8
+GIGACHAT_API_BASE=http://localhost:8000
+GIGACHAT_API_KEY=
+GIGACHAT_MODEL=gigachat
+LLM_PROVIDER=openai
+GIGACHAT_CERT_FILE=
+GIGACHAT_KEY_FILE=
+GIGACHAT_CA_FILE=

--- a/src/main/java/com/example/agent/api/TranslatorEngine.java
+++ b/src/main/java/com/example/agent/api/TranslatorEngine.java
@@ -29,7 +29,7 @@ public class TranslatorEngine implements TranslatorApi {
     public static TranslatorEngine fromEnv(Path runtimeDir) throws IOException {
         var cfg = Config.fromEnv();
         LlmProvider provider;
-        if ("cert".equalsIgnoreCase(cfg.provider)) {
+        if (!cfg.certPath.isBlank() && !cfg.keyPath.isBlank() && !cfg.caPath.isBlank()) {
             try {
                 provider = new GigaChatCertificateClient(cfg.apiBase, cfg.model,
                         Path.of(cfg.certPath), Path.of(cfg.keyPath), Path.of(cfg.caPath));

--- a/src/main/java/com/example/agent/api/TranslatorEngine.java
+++ b/src/main/java/com/example/agent/api/TranslatorEngine.java
@@ -3,7 +3,9 @@ package com.example.agent.api;
 import com.example.agent.bootstrap.Learner;
 import com.example.agent.config.Config;
 import com.example.agent.knowledge.RuleStore;
+import com.example.agent.providers.GigaChatCertificateClient;
 import com.example.agent.providers.GigaChatOpenAIClient;
+import com.example.agent.providers.LlmProvider;
 import com.example.agent.rag.SimpleIndexer;
 import com.example.agent.translate.TranslatorAgent;
 
@@ -14,19 +16,30 @@ import java.util.Objects;
 
 public class TranslatorEngine implements TranslatorApi {
 
-    private final GigaChatOpenAIClient llm;
+    private final LlmProvider llm;
     private final RuleStore rules;
     private final SimpleIndexer indexer;
 
-    public TranslatorEngine(String apiBase, String apiKey, String model, Path runtimeDir) throws IOException {
-        this.llm = new GigaChatOpenAIClient(Objects.requireNonNull(apiBase), Objects.requireNonNull(apiKey), Objects.requireNonNull(model));
+    public TranslatorEngine(LlmProvider llm, Path runtimeDir) throws IOException {
+        this.llm = Objects.requireNonNull(llm);
         this.rules = new RuleStore(Objects.requireNonNull(runtimeDir));
         this.indexer = new SimpleIndexer();
     }
 
     public static TranslatorEngine fromEnv(Path runtimeDir) throws IOException {
         var cfg = Config.fromEnv();
-        return new TranslatorEngine(cfg.apiBase, cfg.apiKey, cfg.model, runtimeDir);
+        LlmProvider provider;
+        if ("cert".equalsIgnoreCase(cfg.provider)) {
+            try {
+                provider = new GigaChatCertificateClient(cfg.apiBase, cfg.model,
+                        Path.of(cfg.certPath), Path.of(cfg.keyPath), Path.of(cfg.caPath));
+            } catch (Exception e) {
+                throw new IOException("Failed to initialize certificate client", e);
+            }
+        } else {
+            provider = new GigaChatOpenAIClient(cfg.apiBase, cfg.apiKey, cfg.model);
+        }
+        return new TranslatorEngine(provider, runtimeDir);
     }
 
     @Override

--- a/src/main/java/com/example/agent/bootstrap/Improver.java
+++ b/src/main/java/com/example/agent/bootstrap/Improver.java
@@ -2,7 +2,7 @@ package com.example.agent.bootstrap;
 
 import com.example.agent.knowledge.Rule;
 import com.example.agent.knowledge.RuleStore;
-import com.example.agent.providers.GigaChatOpenAIClient;
+import com.example.agent.providers.LlmProvider;
 
 import java.io.IOException;
 import java.util.List;
@@ -14,10 +14,10 @@ import java.util.Map;
  */
 public class Improver {
 
-    private final GigaChatOpenAIClient llm;
+    private final LlmProvider llm;
     private final RuleStore store;
 
-    public Improver(GigaChatOpenAIClient llm, RuleStore store) {
+    public Improver(LlmProvider llm, RuleStore store) {
         this.llm = llm;
         this.store = store;
     }

--- a/src/main/java/com/example/agent/bootstrap/Learner.java
+++ b/src/main/java/com/example/agent/bootstrap/Learner.java
@@ -2,7 +2,7 @@ package com.example.agent.bootstrap;
 
 import com.example.agent.knowledge.Rule;
 import com.example.agent.knowledge.RuleStore;
-import com.example.agent.providers.GigaChatOpenAIClient;
+import com.example.agent.providers.LlmProvider;
 import com.example.agent.rag.SimpleIndexer;
 
 import java.io.IOException;
@@ -13,11 +13,11 @@ import java.util.regex.Pattern;
 
 public class Learner {
 
-    private final GigaChatOpenAIClient llm;
+    private final LlmProvider llm;
     private final RuleStore store;
     private final SimpleIndexer indexer;
 
-    public Learner(GigaChatOpenAIClient llm, RuleStore store, SimpleIndexer indexer) {
+    public Learner(LlmProvider llm, RuleStore store, SimpleIndexer indexer) {
         this.llm = llm;
         this.store = store;
         this.indexer = indexer;

--- a/src/main/java/com/example/agent/config/Config.java
+++ b/src/main/java/com/example/agent/config/Config.java
@@ -21,18 +21,20 @@ public class Config {
     }
 
     public static Config fromEnv() {
-        String base = getenvOr("GIGACHAT_API_BASE", "http://localhost:8000");
-        String key  = getenvOr("GIGACHAT_API_KEY", "");
-        String model= getenvOr("GIGACHAT_MODEL", "gigachat");
-        String provider = getenvOr("LLM_PROVIDER", "openai");
-        String cert = getenvOr("GIGACHAT_CERT_FILE", "");
-        String kpath = getenvOr("GIGACHAT_KEY_FILE", "");
-        String ca   = getenvOr("GIGACHAT_CA_FILE", "");
+        String base = propOrEnv("GIGACHAT_API_BASE", "http://localhost:8000");
+        String key  = propOrEnv("GIGACHAT_API_KEY", "");
+        String model= propOrEnv("GIGACHAT_MODEL", "gigachat");
+        String provider = propOrEnv("LLM_PROVIDER", "openai");
+        String cert = propOrEnv("GIGACHAT_CERT_FILE", "");
+        String kpath = propOrEnv("GIGACHAT_KEY_FILE", "");
+        String ca   = propOrEnv("GIGACHAT_CA_FILE", "");
         return new Config(base, key, model, provider, cert, kpath, ca);
     }
 
-    private static String getenvOr(String k, String def) {
-        String v = System.getenv(k);
+    private static String propOrEnv(String k, String def) {
+        String v = System.getProperty(k);
+        if (v != null && !v.isBlank()) return v;
+        v = System.getenv(k);
         return v == null || v.isBlank() ? def : v;
     }
 }

--- a/src/main/java/com/example/agent/config/Config.java
+++ b/src/main/java/com/example/agent/config/Config.java
@@ -4,18 +4,31 @@ public class Config {
     public final String apiBase;
     public final String apiKey;
     public final String model;
+    public final String provider;
+    public final String certPath;
+    public final String keyPath;
+    public final String caPath;
 
-    public Config(String apiBase, String apiKey, String model) {
+    public Config(String apiBase, String apiKey, String model,
+                  String provider, String certPath, String keyPath, String caPath) {
         this.apiBase = apiBase;
         this.apiKey = apiKey;
         this.model = model;
+        this.provider = provider;
+        this.certPath = certPath;
+        this.keyPath = keyPath;
+        this.caPath = caPath;
     }
 
     public static Config fromEnv() {
         String base = getenvOr("GIGACHAT_API_BASE", "http://localhost:8000");
-        String key  = getenvOr("GIGACHAT_API_KEY", "CHANGE_ME");
+        String key  = getenvOr("GIGACHAT_API_KEY", "");
         String model= getenvOr("GIGACHAT_MODEL", "gigachat");
-        return new Config(base, key, model);
+        String provider = getenvOr("LLM_PROVIDER", "openai");
+        String cert = getenvOr("GIGACHAT_CERT_FILE", "");
+        String kpath = getenvOr("GIGACHAT_KEY_FILE", "");
+        String ca   = getenvOr("GIGACHAT_CA_FILE", "");
+        return new Config(base, key, model, provider, cert, kpath, ca);
     }
 
     private static String getenvOr(String k, String def) {

--- a/src/main/java/com/example/agent/providers/GigaChatCertificateClient.java
+++ b/src/main/java/com/example/agent/providers/GigaChatCertificateClient.java
@@ -1,0 +1,113 @@
+package com.example.agent.providers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.*;
+
+import javax.net.ssl.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.*;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Client for GigaChat using mTLS authentication with certificate files.
+ */
+public class GigaChatCertificateClient implements LlmProvider {
+
+    private final String baseUrl;
+    private final String model;
+    private final OkHttpClient http;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    public GigaChatCertificateClient(String baseUrl, String model,
+                                     Path certFile, Path keyFile, Path caFile)
+            throws GeneralSecurityException, IOException {
+        this.baseUrl = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length()-1) : baseUrl;
+        this.model = model;
+        this.http = buildClient(certFile, keyFile, caFile);
+    }
+
+    private OkHttpClient buildClient(Path certFile, Path keyFile, Path caFile)
+            throws GeneralSecurityException, IOException {
+        X509Certificate cert = readCert(certFile);
+        PrivateKey key = readKey(keyFile);
+        X509Certificate ca = readCert(caFile);
+
+        KeyStore ks = KeyStore.getInstance("PKCS12");
+        ks.load(null, null);
+        ks.setKeyEntry("client", key, new char[0], new Certificate[]{cert});
+
+        KeyStore ts = KeyStore.getInstance(KeyStore.getDefaultType());
+        ts.load(null, null);
+        ts.setCertificateEntry("ca", ca);
+
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        kmf.init(ks, new char[0]);
+
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        tmf.init(ts);
+
+        SSLContext ctx = SSLContext.getInstance("TLS");
+        ctx.init(kmf.getKeyManagers(), tmf.getTrustManagers(), new SecureRandom());
+        X509TrustManager tm = (X509TrustManager) tmf.getTrustManagers()[0];
+
+        return new OkHttpClient.Builder()
+                .sslSocketFactory(ctx.getSocketFactory(), tm)
+                .callTimeout(Duration.ofSeconds(60))
+                .build();
+    }
+
+    private X509Certificate readCert(Path path) throws IOException, GeneralSecurityException {
+        try (InputStream in = Files.newInputStream(path)) {
+            return (X509Certificate) CertificateFactory.getInstance("X.509").generateCertificate(in);
+        }
+    }
+
+    private PrivateKey readKey(Path path) throws IOException, GeneralSecurityException {
+        String pem = Files.readString(path);
+        pem = pem.replace("-----BEGIN PRIVATE KEY-----", "")
+                 .replace("-----END PRIVATE KEY-----", "")
+                 .replaceAll("\\s", "");
+        byte[] bytes = Base64.getDecoder().decode(pem);
+        PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(bytes);
+        try {
+            return KeyFactory.getInstance("RSA").generatePrivate(spec);
+        } catch (GeneralSecurityException e) {
+            return KeyFactory.getInstance("EC").generatePrivate(spec);
+        }
+    }
+
+    @Override
+    public String chat(List<Map<String, String>> messages, double temperature) throws IOException {
+        String url = baseUrl + "/v1/chat/completions";
+        var payload = Map.of(
+                "model", model,
+                "messages", messages,
+                "temperature", temperature
+        );
+        RequestBody body = RequestBody.create(
+                mapper.writeValueAsBytes(payload),
+                MediaType.parse("application/json")
+        );
+        Request req = new Request.Builder()
+                .url(url)
+                .post(body)
+                .build();
+        try (Response resp = http.newCall(req).execute()) {
+            if (!resp.isSuccessful()) {
+                throw new IOException("GigaChat API error: " + resp.code() + " " + resp.message() + " body=" + (resp.body() != null ? resp.body().string() : ""));
+            }
+            JsonNode json = mapper.readTree(resp.body().bytes());
+            return json.get("choices").get(0).get("message").get("content").asText();
+        }
+    }
+}

--- a/src/main/java/com/example/agent/providers/GigaChatCertificateClient.java
+++ b/src/main/java/com/example/agent/providers/GigaChatCertificateClient.java
@@ -13,6 +13,7 @@ import java.security.*;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.security.spec.PKCS8EncodedKeySpec;
 import java.time.Duration;
 import java.util.Base64;
 import java.util.List;

--- a/src/main/java/com/example/agent/providers/GigaChatOpenAIClient.java
+++ b/src/main/java/com/example/agent/providers/GigaChatOpenAIClient.java
@@ -9,7 +9,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 
-public class GigaChatOpenAIClient {
+public class GigaChatOpenAIClient implements LlmProvider {
 
     private final String baseUrl; // e.g. http://localhost:8000
     private final String apiKey;
@@ -26,6 +26,7 @@ public class GigaChatOpenAIClient {
                 .build();
     }
 
+    @Override
     public String chat(List<Map<String, String>> messages, double temperature) throws IOException {
         String url = baseUrl + "/v1/chat/completions";
         var payload = Map.of(

--- a/src/main/java/com/example/agent/providers/LlmProvider.java
+++ b/src/main/java/com/example/agent/providers/LlmProvider.java
@@ -1,0 +1,19 @@
+package com.example.agent.providers;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Generic interface for large language model providers.
+ */
+public interface LlmProvider {
+    /**
+     * Sends chat messages to the model and returns the generated response.
+     *
+     * @param messages    list of role/content message maps
+     * @param temperature sampling temperature
+     * @return model output text
+     */
+    String chat(List<Map<String, String>> messages, double temperature) throws IOException;
+}

--- a/src/main/java/com/example/agent/translate/TranslatorAgent.java
+++ b/src/main/java/com/example/agent/translate/TranslatorAgent.java
@@ -3,7 +3,7 @@ package com.example.agent.translate;
 import com.example.agent.bootstrap.Improver;
 import com.example.agent.knowledge.RuleStore;
 import com.example.agent.model.ir.IR;
-import com.example.agent.providers.GigaChatOpenAIClient;
+import com.example.agent.providers.LlmProvider;
 import com.example.agent.rag.SimpleIndexer;
 
 import java.io.IOException;
@@ -12,7 +12,7 @@ import java.util.Map;
 
 public class TranslatorAgent {
 
-    private final GigaChatOpenAIClient llm;
+    private final LlmProvider llm;
     private final SimpleIndexer indexer;
     private final RuleStore ruleStore;
     private final DynamicDialectParser parser;
@@ -20,7 +20,7 @@ public class TranslatorAgent {
     private final JavaVerifier verifier = new JavaVerifier();
     private final Improver improver;
 
-    public TranslatorAgent(GigaChatOpenAIClient llm, SimpleIndexer indexer, RuleStore ruleStore) {
+    public TranslatorAgent(LlmProvider llm, SimpleIndexer indexer, RuleStore ruleStore) {
         this.llm = llm;
         this.indexer = indexer;
         this.ruleStore = ruleStore;


### PR DESCRIPTION
## Summary
- define `LlmProvider` interface for chat completion clients
- add certificate-based `GigaChatCertificateClient`
- allow choosing provider via `Config` and select implementation in `TranslatorEngine`

## Testing
- `./gradlew test` *(fails: Could not resolve com.squareup.okhttp3:okhttp:4.12.0 ... Received status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e6018dc88320a66ee5218ade2259