### PR TITLE
Add control flow parsing and Java generation

### DIFF
--- a/src/main/java/com/example/agent/rules/BlockEngine.java
+++ b/src/main/java/com/example/agent/rules/BlockEngine.java
@@ -21,7 +21,22 @@ public final class BlockEngine {
     }
   }
 
+  private static final Pattern P_BEGIN = Pattern.compile("^\\s*BEGIN\\s*;?\\s*$", Pattern.CASE_INSENSITIVE);
+  private static final Pattern P_END_ONLY = Pattern.compile("^\\s*END\\s*;?\\s*$", Pattern.CASE_INSENSITIVE);
+
   public IR parse(List<String> tokens, List<RuleV2> blockRules, List<RuleV2> stmtRules) {
+    if (blockRules == null) blockRules = List.of();
+    if (stmtRules == null) stmtRules = List.of();
+
+    // filter BEGIN/END
+    List<String> filtered = new ArrayList<>();
+    for (String t : tokens) {
+      if (P_BEGIN.matcher(t).matches()) continue;
+      if (P_END_ONLY.matcher(t).matches()) continue;
+      filtered.add(t);
+    }
+    tokens = filtered;
+
     List<CompBlock> blocks = new ArrayList<>();
     blockRules.stream().sorted((a,b)->Integer.compare(b.priority, a.priority)).forEach(r -> blocks.add(new CompBlock(r)));
     var ir = new IR();

--- a/src/main/java/com/example/agent/rules/BuiltInRules.java
+++ b/src/main/java/com/example/agent/rules/BuiltInRules.java
@@ -1,0 +1,40 @@
+package com.example.agent.rules;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Predefined rule sets used when no learned rules exist. */
+public final class BuiltInRules {
+  private BuiltInRules() {}
+
+  /** Built-in block rules such as IF/ELSE. */
+  public static List<RuleV2> blockRules() {
+    RuleV2 ifRule = new RuleV2();
+    ifRule.irType = "If";
+    ifRule.open = "^\\s*IF\\s+(.+)\\s+THEN\\s*$";
+    ifRule.middle = new String[]{"^\\s*ELSE\\s*$"};
+    ifRule.close = "^\\s*END\\s*IF\\s*;?\\s*$";
+    ifRule.fields = new String[]{"cond"};
+    return List.of(ifRule);
+  }
+
+  /** Built-in statement rules such as assignments and calls. */
+  public static List<RuleV2> stmtRules() {
+    List<RuleV2> out = new ArrayList<>();
+
+    RuleV2 assign = new RuleV2();
+    assign.irType = "Assign";
+    assign.regex = "^\\s*([A-Za-z_][A-Za-z0-9_]*)\\s*:=\\s*(.+?);?\\s*$";
+    assign.fields = new String[]{"name","expr"};
+    out.add(assign);
+
+    RuleV2 call = new RuleV2();
+    call.irType = "Call";
+    call.regex = "^\\s*([A-Za-z_][A-Za-z0-9_]*)\\s*\\((.*)\\)\\s*;?\\s*$";
+    call.fields = new String[]{"callee","args"};
+    call.listFields = new String[]{"args"};
+    out.add(call);
+
+    return out;
+  }
+}

--- a/src/main/java/com/example/agent/translate/IRToJava.java
+++ b/src/main/java/com/example/agent/translate/IRToJava.java
@@ -9,35 +9,53 @@ public class IRToJava {
         sb.append("public class ").append(className).append(" {\n");
         sb.append("  public static void main(String[] args) {\n");
         for (IR.Node n : ir.nodes) {
-            sb.append("    ").append(genStmt(n)).append("\n");
+            genStmt(sb, n, 2);
         }
         sb.append("  }\n");
         sb.append("}\n");
         return sb.toString();
     }
 
-    private String genStmt(IR.Node n) {
+    private void genStmt(StringBuilder sb, IR.Node n, int indent) {
         if (n instanceof IR.Assign a) {
-            return "var " + a.name + " = " + sanitize(a.expr) + ";";
+            indent(sb, indent); sb.append("var ").append(a.name).append(" = ").append(sanitize(a.expr)).append(";\n");
+            return;
         }
         if (n instanceof IR.Call c) {
-            String args = String.join(", ", c.args);
-            return c.callee + "(" + args + ");";
+            indent(sb, indent);
+            String args = c.args.stream().map(this::sanitize).collect(java.util.stream.Collectors.joining(", "));
+            sb.append(c.callee).append("(").append(args).append(");\n");
+            return;
         }
         if (n instanceof IR.Decl d) {
-            return d.type + " " + d.name + ";";
+            indent(sb, indent); sb.append(d.type).append(' ').append(d.name).append(";\n");
+            return;
         }
         if (n instanceof IR.If i) {
-            return "if (" + sanitize(i.cond) + ") { /* TODO then */ } else { /* TODO else */ }";
+            indent(sb, indent); sb.append("if (").append(sanitize(i.cond)).append(") {\n");
+            for (IR.Node ch : i.thenBody) genStmt(sb, ch, indent + 1);
+            indent(sb, indent); sb.append('}');
+            if (!i.elseBody.isEmpty()) {
+                sb.append(" else {\n");
+                for (IR.Node ch : i.elseBody) genStmt(sb, ch, indent + 1);
+                indent(sb, indent); sb.append('}');
+            }
+            sb.append("\n");
+            return;
         }
         if (n instanceof IR.Loop l) {
-            return "// loop " + l.header + "\n    /* TODO convert loop body */";
+            indent(sb, indent); sb.append("// loop ").append(l.header).append("\n");
+            for (IR.Node ch : l.body) genStmt(sb, ch, indent + 1);
+            return;
         }
         if (n instanceof IR.UnknownNode u) {
-            return "/* UNKNOWN: " + escape(u.raw) + " */";
+            indent(sb, indent); sb.append("/* UNKNOWN: ").append(escape(u.raw)).append(" */\n");
+            return;
         }
-        return "/* TODO */";
+        indent(sb, indent); sb.append("/* TODO */\n");
     }
+
+    private void indent(StringBuilder sb, int lvl) { for (int i = 0; i < lvl; i++) sb.append("  "); }
 
     private String sanitize(String s) {
         return s

--- a/src/main/java/com/example/agent/translate/TranslatorAgent.java
+++ b/src/main/java/com/example/agent/translate/TranslatorAgent.java
@@ -8,6 +8,7 @@ import com.example.agent.rag.SimpleIndexer;
 import com.example.agent.rules.*;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -31,7 +32,11 @@ public class TranslatorAgent {
     var seg = new SegmentEngine().segment(source, rules.ofType("segment"));
 
     // 2) Blocks + statements
-    IR ir = new BlockEngine().parse(seg, rules.ofType("block"), rules.ofType("stmt"));
+    List<RuleV2> blockRules = new ArrayList<>(rules.ofType("block"));
+    blockRules.addAll(BuiltInRules.blockRules());
+    List<RuleV2> stmtRules = new ArrayList<>(rules.ofType("stmt"));
+    stmtRules.addAll(BuiltInRules.stmtRules());
+    IR ir = new BlockEngine().parse(seg, blockRules, stmtRules);
 
     // 3) Generate Java
     String className = "TranslatedProgram";

--- a/src/test/java/com/example/agent/IfBlockTest.java
+++ b/src/test/java/com/example/agent/IfBlockTest.java
@@ -1,0 +1,35 @@
+package com.example.agent;
+
+import com.example.agent.model.ir.IR;
+import com.example.agent.rules.BlockEngine;
+import com.example.agent.rules.BuiltInRules;
+import com.example.agent.translate.IRToJava;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class IfBlockTest {
+
+    @Test
+    void parsesIfAndGeneratesJava() {
+        List<String> tokens = List.of(
+                "BEGIN",
+                "x := 1;",
+                "IF x > 0 THEN",
+                "  y := 2;",
+                "ELSE",
+                "  print(y);",
+                "END IF;",
+                "END;"
+        );
+        IR ir = new BlockEngine().parse(tokens, BuiltInRules.blockRules(), BuiltInRules.stmtRules());
+        String java = new IRToJava().generate(ir, "Sample");
+
+        assertTrue(java.contains("var x = 1"));
+        assertTrue(java.contains("if (x > 0)"));
+        assertTrue(java.contains("print(y);"));
+    }
+}
+


### PR DESCRIPTION
## Summary
- move IF/assignment/call patterns into reusable BuiltInRules lists
- feed BlockEngine with external rule lists instead of hardcoded defaults
- update TranslatorAgent and tests to use built-in rule sets

## Testing
- `./gradlew test` *(fails: Could not resolve org.junit.jupiter:junit-jupiter:5.10.2, 403 Forbidden)*
- `./gradlew compileJava`


------
https://chatgpt.com/codex/tasks/task_e_68c2af3cf3bc8320b48cf8d130590950