### PR TITLE
Add document-driven grammar extraction and seeding

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,8 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.1'
     implementation 'com.fasterxml.jackson.core:jackson-annotations:2.17.1'
     implementation 'com.fasterxml.jackson.core:jackson-core:2.17.1'
+    implementation 'org.apache.poi:poi-ooxml:5.2.3'
+    implementation 'org.apache.poi:poi:5.2.3'
 
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
 }

--- a/src/main/java/com/example/agent/cli/Main.java
+++ b/src/main/java/com/example/agent/cli/Main.java
@@ -1,6 +1,10 @@
 package com.example.agent.cli;
 
 import com.example.agent.api.TranslatorEngine;
+import com.example.agent.docs.DocGrammarExtractor;
+import com.example.agent.grammar.GrammarSeeder;
+import com.example.agent.grammar.GrammarStore;
+import com.example.agent.rules.RuleLoaderV2;
 
 import java.nio.file.Path;
 import java.nio.file.Files;
@@ -9,11 +13,21 @@ import java.util.Arrays;
 public class Main {
     public static void main(String[] args) throws Exception {
         if (args.length == 0) {
-            System.out.println("Usage:\n  learn <repoRoot> [exts=.dlx,.dsl,.txt] [runtime=runtime]\n  translate <file> [runtime=runtime]\n  fix <dialectFile> <javaFile> <feedback.txt> [runtime=runtime]\n");
+            System.out.println("Usage:\n  learn <repoRoot> [exts=.dlx,.dsl,.txt] [runtime=runtime]\n  translate <file> [runtime=runtime]\n  fix <dialectFile> <javaFile> <feedback.txt> [runtime=runtime]\n  learn-doc <spec.docx> [runtime=runtime]\n");
             return;
         }
         String cmd = args[0];
         switch (cmd) {
+            case "learn-doc" -> {
+                Path doc = Path.of(args[1]);
+                Path runtime = Path.of(args.length >= 3 ? args[2] : "runtime");
+                GrammarStore gs = new GrammarStore(runtime);
+                new DocGrammarExtractor().extract(doc, gs);
+                gs.save();
+                var repo = new RuleLoaderV2(runtime);
+                new GrammarSeeder().seed(gs, repo);
+                System.out.println("Doc learn OK");
+            }
             case "learn" -> {
                 Path repo = Path.of(args[1]);
                 String exts = args.length >= 3 ? args[2] : ".dlx,.dsl,.txt";

--- a/src/main/java/com/example/agent/docs/DocGrammarExtractor.java
+++ b/src/main/java/com/example/agent/docs/DocGrammarExtractor.java
@@ -1,0 +1,100 @@
+package com.example.agent.docs;
+
+import com.example.agent.grammar.GrammarStore;
+import com.example.agent.grammar.GrammarStore.Block;
+import com.example.agent.grammar.GrammarStore.FunctionSig;
+import org.apache.poi.hwpf.HWPFDocument;
+import org.apache.poi.hwpf.extractor.WordExtractor;
+import org.apache.poi.xwpf.usermodel.XWPFDocument;
+import org.apache.poi.xwpf.usermodel.XWPFParagraph;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/** Extracts grammar hints (keywords, blocks, macros, functions) from DOC/DOCX. */
+public class DocGrammarExtractor {
+    private static final Pattern KEYWORD = Pattern.compile("\\b[A-Z][A-Z0-9_]{1,}\\b");
+    private static final Pattern MACRO = Pattern.compile("&([A-Za-z_][A-Za-z0-9_]*)\\s*\\(");
+    private static final Pattern FUNC = Pattern.compile("([A-Za-z_][A-Za-z0-9_]*)\\s*\\(([^)]*)\\)");
+    private static final Pattern END_BLOCK = Pattern.compile("\\bEND\\s+([A-Z][A-Z0-9_]*)\\b");
+
+    public void extract(Path docPath, GrammarStore store) throws IOException {
+        List<String> lines = readLines(docPath);
+        Map<String, Set<String>> mids = new HashMap<>();
+        Set<String> opens = new LinkedHashSet<>();
+
+        for (String line : lines) {
+            Matcher kw = KEYWORD.matcher(line);
+            while (kw.find()) {
+                store.keywords.add(kw.group());
+            }
+            Matcher mc = MACRO.matcher(line);
+            if (mc.find()) {
+                store.macros.add("&");
+            }
+            Matcher fn = FUNC.matcher(line);
+            while (fn.find()) {
+                String name = fn.group(1);
+                String args = fn.group(2);
+                if (name.startsWith("&")) continue;
+                FunctionSig fs = new FunctionSig();
+                fs.name = name;
+                fs.args = Arrays.stream(args.split(","))
+                        .map(String::trim)
+                        .filter(s -> !s.isEmpty())
+                        .toList();
+                store.functions.add(fs);
+            }
+            Matcher end = END_BLOCK.matcher(line);
+            while (end.find()) {
+                String open = end.group(1);
+                opens.add(open);
+            }
+            for (String o : opens) {
+                if (line.contains(o)) {
+                    Matcher t = KEYWORD.matcher(line);
+                    while (t.find()) {
+                        String tok = t.group();
+                        if (!tok.equals(o) && !tok.equals("END")) {
+                            mids.computeIfAbsent(o, k -> new LinkedHashSet<>()).add(tok);
+                        }
+                    }
+                }
+            }
+        }
+
+        for (String o : opens) {
+            Block b = new Block();
+            b.open = o;
+            b.close = "END " + o;
+            Set<String> ms = mids.get(o);
+            if (ms != null && !ms.isEmpty()) b.middle = new ArrayList<>(ms);
+            store.blocks.add(b);
+        }
+    }
+
+    private List<String> readLines(Path doc) throws IOException {
+        String fn = doc.getFileName().toString().toLowerCase();
+        List<String> lines = new ArrayList<>();
+        try (InputStream is = Files.newInputStream(doc)) {
+            if (fn.endsWith(".docx")) {
+                XWPFDocument x = new XWPFDocument(is);
+                for (XWPFParagraph p : x.getParagraphs()) {
+                    lines.add(p.getText());
+                }
+            } else if (fn.endsWith(".doc")) {
+                HWPFDocument h = new HWPFDocument(is);
+                WordExtractor e = new WordExtractor(h);
+                lines.addAll(Arrays.asList(e.getParagraphText()));
+            } else {
+                throw new IOException("Unsupported document: " + doc);
+            }
+        }
+        return lines;
+    }
+}

--- a/src/main/java/com/example/agent/grammar/GrammarSeeder.java
+++ b/src/main/java/com/example/agent/grammar/GrammarSeeder.java
@@ -1,0 +1,105 @@
+package com.example.agent.grammar;
+
+import com.example.agent.rules.RuleLoaderV2;
+import com.example.agent.rules.RuleV2;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/** Seeds RuleLoaderV2 with generic rules derived from GrammarStore. */
+public class GrammarSeeder {
+    public void seed(GrammarStore store, RuleLoaderV2 repo) throws IOException {
+        // segment: semicolon
+        RuleV2 semi = new RuleV2();
+        semi.id = "segment_semicolon";
+        semi.type = "segment";
+        semi.strategy = "regex_outside_quotes_parens";
+        semi.regex = ";";
+        repo.addOrMerge(semi);
+
+        // segment: keywords
+        for (String kw : store.keywords) {
+            RuleV2 r = new RuleV2();
+            r.id = "seg_kw_" + kw.toLowerCase();
+            r.type = "segment";
+            r.strategy = "regex_boundary_keep";
+            r.regex = "\\b" + Pattern.quote(kw) + "\\b";
+            repo.addOrMerge(r);
+        }
+
+        // block rules
+        for (GrammarStore.Block b : store.blocks) {
+            RuleV2 r = new RuleV2();
+            r.id = "block_" + b.open.toLowerCase();
+            r.type = "block";
+            r.irType = "UnknownNode";
+            r.open = "^\\s*(" + Pattern.quote(b.open) + ".*)$";
+            r.close = "^\\s*" + Pattern.quote(b.close) + ".*$";
+            if (b.middle != null && !b.middle.isEmpty()) {
+                List<String> mids = new ArrayList<>();
+                for (String m : b.middle) {
+                    mids.add("^\\s*" + Pattern.quote(m) + ".*$");
+                    // also ensure segment rule for middle tokens
+                    RuleV2 mr = new RuleV2();
+                    mr.id = "seg_kw_" + m.toLowerCase();
+                    mr.type = "segment";
+                    mr.strategy = "regex_boundary_keep";
+                    mr.regex = "\\b" + Pattern.quote(m) + "\\b";
+                    repo.addOrMerge(mr);
+                }
+                r.middle = mids.toArray(new String[0]);
+            }
+            r.fields = new String[]{"raw"};
+            repo.addOrMerge(r);
+            // ensure segment rules for open and close tokens
+            for (String tok : (b.open + " " + b.close).split("\\s+")) {
+                RuleV2 sr = new RuleV2();
+                sr.id = "seg_kw_" + tok.toLowerCase();
+                sr.type = "segment";
+                sr.strategy = "regex_boundary_keep";
+                sr.regex = "\\b" + Pattern.quote(tok) + "\\b";
+                repo.addOrMerge(sr);
+            }
+        }
+
+        // stmt rules
+        RuleV2 assign = new RuleV2();
+        assign.id = "stmt_assign";
+        assign.type = "stmt";
+        assign.irType = "Assign";
+        assign.regex = "^\\s*([A-Za-z_][A-Za-z0-9_]*)\\s*:=\\s*(.+);?\\s*$";
+        assign.fields = new String[]{"name","expr"};
+        repo.addOrMerge(assign);
+
+        RuleV2 decl = new RuleV2();
+        decl.id = "stmt_decl";
+        decl.type = "stmt";
+        decl.irType = "Decl";
+        decl.regex = "^\\s*DECLARE\\s+([A-Za-z_][A-Za-z0-9_]*)\\s*:\\s*(.+);?\\s*$";
+        decl.fields = new String[]{"name","type"};
+        repo.addOrMerge(decl);
+
+        RuleV2 call = new RuleV2();
+        call.id = "stmt_call";
+        call.type = "stmt";
+        call.irType = "Call";
+        call.regex = "^\\s*([&]?[A-Za-z_][A-Za-z0-9_]*)\\s*\\((.*)\\)\\s*;?\\s*$";
+        call.fields = new String[]{"callee","args"};
+        call.listFields = new String[]{"args"};
+        repo.addOrMerge(call);
+
+        // macros rewrite
+        if (!store.macros.isEmpty()) {
+            RuleV2 rw = new RuleV2();
+            rw.id = "rewrite_macro_call";
+            rw.type = "rewrite";
+            rw.pattern = "&([A-Za-z_][A-Za-z0-9_]*)\\s*\\((.*)\\)";
+            rw.replace = "$1($2)";
+            repo.addOrMerge(rw);
+        }
+
+        repo.save();
+    }
+}

--- a/src/main/java/com/example/agent/grammar/GrammarStore.java
+++ b/src/main/java/com/example/agent/grammar/GrammarStore.java
@@ -1,0 +1,82 @@
+package com.example.agent.grammar;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
+
+/** Stores grammar artifacts extracted from documentation. */
+public class GrammarStore {
+    public static class Block {
+        public String open;
+        public List<String> middle;
+        public String close;
+    }
+    public static class FunctionSig {
+        public String name;
+        public List<String> args;
+    }
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final Path dir;
+
+    public List<Block> blocks = new ArrayList<>();
+    public Set<String> keywords = new LinkedHashSet<>();
+    public Set<String> macros = new LinkedHashSet<>();
+    public List<FunctionSig> functions = new ArrayList<>();
+
+    public GrammarStore(Path runtimeDir) throws IOException {
+        this.dir = runtimeDir.resolve("grammar");
+        Files.createDirectories(dir);
+        load();
+    }
+
+    public void load() throws IOException {
+        // blocks
+        Path g = dir.resolve("grammar.json");
+        if (Files.exists(g)) {
+            Block[] bs = mapper.readValue(Files.readString(g), Block[].class);
+            blocks = new ArrayList<>(Arrays.asList(bs));
+        }
+        // keywords
+        Path k = dir.resolve("keywords.json");
+        if (Files.exists(k)) {
+            String[] arr = mapper.readValue(Files.readString(k), String[].class);
+            keywords.addAll(Arrays.asList(arr));
+        }
+        // macros
+        Path m = dir.resolve("macros.json");
+        if (Files.exists(m)) {
+            String[] arr = mapper.readValue(Files.readString(m), String[].class);
+            macros.addAll(Arrays.asList(arr));
+        }
+        // functions
+        Path f = dir.resolve("functions.jsonl");
+        if (Files.exists(f)) {
+            functions.clear();
+            for (String line : Files.readAllLines(f)) {
+                line = line.trim();
+                if (line.isEmpty()) continue;
+                functions.add(mapper.readValue(line, FunctionSig.class));
+            }
+        }
+    }
+
+    public void save() throws IOException {
+        // blocks
+        mapper.writeValue(dir.resolve("grammar.json").toFile(), blocks);
+        // keywords
+        mapper.writeValue(dir.resolve("keywords.json").toFile(), keywords);
+        // macros
+        mapper.writeValue(dir.resolve("macros.json").toFile(), macros);
+        // functions
+        Path f = dir.resolve("functions.jsonl");
+        List<String> lines = new ArrayList<>();
+        for (FunctionSig fn : functions) {
+            lines.add(mapper.writeValueAsString(fn));
+        }
+        Files.write(f, lines);
+    }
+}


### PR DESCRIPTION
## Summary
- Parse DOC/DOCX specs into keywords, blocks, functions and macros
- Seed initial segment, block, stmt and rewrite rules from extracted grammar
- Support `regex_boundary_keep` segmentation and new `learn-doc` CLI command

## Testing
- `./gradlew test` *(fails: Could not resolve org.apache.poi:poi-ooxml:5.2.3)*

------
https://chatgpt.com/codex/tasks/task_e_68c2db5c546483209fb7c222786e40d4