### PR TITLE
Enable nested parentheses in amp macro rewrites

### DIFF
--- a/spec/plplus_syntax_manifest.json
+++ b/spec/plplus_syntax_manifest.json
@@ -383,7 +383,7 @@
       "priority": 9
     },
     { "id": "rw_amp_macro_strict",
-      "pattern": "&([A-Za-z_][A-Za-z0-9_]*)\\s*\\(([^()]*)\\)",
+      "pattern": "&([A-Za-z_][A-Za-z0-9_]*)\\s*\\((.*)\\)",
       "replace": "$1($2)",
       "priority": 8
     },
@@ -413,7 +413,7 @@
       "priority": 9
     },
     { "id": "rw_amp_macro_strict",
-      "pattern": "&([A-Za-z_][A-Za-z0-9_]*)\\s*\\(([^()]*)\\)",
+      "pattern": "&([A-Za-z_][A-Za-z0-9_]*)\\s*\\((.*)\\)",
       "replace": "$1($2)",
       "priority": 8
     },
@@ -433,7 +433,7 @@
       "priority": 9
     },
     { "id": "rw_amp_macro_strict",
-      "pattern": "&([A-Za-z_][A-Za-z0-9_]*)\\s*\\(([^()]*)\\)",
+      "pattern": "&([A-Za-z_][A-Za-z0-9_]*)\\s*\\((.*)\\)",
       "replace": "$1($2)",
       "priority": 6
     },
@@ -516,7 +516,7 @@
     },
     {
       "id": "rw_amp_macro_strict",
-      "pattern": "&([A-Za-z_][A-Za-z0-9_]*)\\s*\\(([^()]*)\\)",
+      "pattern": "&([A-Za-z_][A-Za-z0-9_]*)\\s*\\((.*)\\)",
       "replace": "$1($2)",
       "priority": 6
     },

--- a/src/main/java/com/example/agent/rules/RewriteEngine.java
+++ b/src/main/java/com/example/agent/rules/RewriteEngine.java
@@ -2,14 +2,80 @@ package com.example.agent.rules;
 
 import java.util.List;
 
+/**
+ * Applies rewrite rules to a source string. For simple regex-based rewrites
+ * {@link String#replaceAll(String, String)} is used. Some rules, like
+ * <code>rw_amp_macro_strict</code>, require balanced-parentheses handling
+ * and are implemented via a custom parser.
+ */
+
 public final class RewriteEngine {
   public String applyAll(String s, List<RuleV2> rewrite) {
     if (s == null) return null;
     String out = s;
     for (RuleV2 r : rewrite) {
+      if ("rw_amp_macro_strict".equals(r.id)) {
+        out = rewriteAmpMacro(out);
+        continue;
+      }
       if (r.pattern == null || r.replace == null) continue;
       try { out = out.replaceAll(r.pattern, r.replace); } catch (Exception ignored) {}
     }
     return out;
+  }
+
+  /**
+   * Rewrites occurrences of <code>&foo(...)</code> to <code>foo(...)</code>,
+   * supporting nested parentheses and quoted strings within the argument list.
+   */
+  private String rewriteAmpMacro(String s) {
+    if (s == null || s.indexOf('&') < 0) return s;
+    StringBuilder out = new StringBuilder();
+    int i = 0;
+    while (i < s.length()) {
+      int amp = s.indexOf('&', i);
+      if (amp < 0) { out.append(s.substring(i)); break; }
+      out.append(s, i, amp);
+      int j = amp + 1;
+      if (j >= s.length() || !Character.isJavaIdentifierStart(s.charAt(j))) {
+        out.append('&');
+        i = j;
+        continue;
+      }
+      int k = j + 1;
+      while (k < s.length() && Character.isJavaIdentifierPart(s.charAt(k))) k++;
+      String id = s.substring(j, k);
+      int t = k;
+      while (t < s.length() && Character.isWhitespace(s.charAt(t))) t++;
+      if (t >= s.length() || s.charAt(t) != '(') {
+        out.append('&').append(id);
+        i = t;
+        continue;
+      }
+      int depth = 0;
+      boolean inString = false; char qc = 0;
+      int m = t;
+      for (; m < s.length(); m++) {
+        char c = s.charAt(m);
+        if (inString) {
+          if (c == qc) inString = false;
+          continue;
+        }
+        if (c == '\'' || c == '"') { inString = true; qc = c; continue; }
+        if (c == '(') depth++;
+        else if (c == ')') {
+          depth--;
+          if (depth == 0) break;
+        }
+      }
+      if (depth != 0) { // unmatched
+        out.append(s.substring(amp));
+        break;
+      }
+      String args = s.substring(t + 1, m);
+      out.append(id).append('(').append(args).append(')');
+      i = m + 1;
+    }
+    return out.toString();
   }
 }

--- a/src/test/java/com/example/agent/AmpMacroRewriteTest.java
+++ b/src/test/java/com/example/agent/AmpMacroRewriteTest.java
@@ -1,0 +1,41 @@
+package com.example.agent;
+
+import com.example.agent.model.ir.IR;
+import com.example.agent.rules.RuleV2;
+import com.example.agent.rules.RewriteEngine;
+import com.example.agent.rules.StmtEngine;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Tests for rw_amp_macro_strict rewrite supporting nested parentheses. */
+public class AmpMacroRewriteTest {
+
+    @Test
+    void rewritesAmpMacroAndStmtCallRecognizes() {
+        // setup rewrite rule
+        RuleV2 rw = new RuleV2();
+        rw.id = "rw_amp_macro_strict";
+        rw.type = "rewrite";
+        rw.pattern = "&([A-Za-z_][A-Za-z0-9_]*)\\s*\\((.*)\\)";
+        rw.replace = "$1($2)";
+
+        RewriteEngine re = new RewriteEngine();
+        String normalized = re.applyAll("&msg(func(1,2));", List.of(rw));
+        assertEquals("msg(func(1,2));", normalized);
+
+        // stmt_call rule
+        RuleV2 sc = new RuleV2();
+        sc.id = "stmt_call";
+        sc.type = "stmt";
+        sc.irType = "Call";
+        sc.regex = "^\\s*([A-Za-z_][A-Za-z0-9_]*)\\s*\\((.*)\\)\\s*;?\\s*$";
+
+        StmtEngine stmt = new StmtEngine();
+        IR.Node n = stmt.match(normalized, List.of(sc));
+        assertTrue(n instanceof IR.Call, "Should parse as Call");
+        assertEquals("msg", ((IR.Call) n).callee);
+    }
+}


### PR DESCRIPTION
## Summary
- handle `&macro(...)` rewrites with balanced parenthesis parser
- broaden `rw_amp_macro_strict` pattern to allow nested calls
- add test exercising amp macro rewrite and `stmt_call` recognition

## Testing
- `./gradlew run --args="translate samples/example.dlx"` *(fails: java.net.UnknownHostException)*
- `./gradlew test` *(fails: Could not resolve junit-jupiter:5.10.2: 403)*
- `java -cp /tmp/classes Main`

------
https://chatgpt.com/codex/tasks/task_e_68c33289740083209b5413743ccabb91