### PR TITLE
test: verify call translation

### DIFF
--- a/src/test/java/com/example/agent/translate/TranslatorAgentTest.java
+++ b/src/test/java/com/example/agent/translate/TranslatorAgentTest.java
@@ -1,0 +1,43 @@
+package com.example.agent.translate;
+
+import com.example.agent.knowledge.RuleStore;
+import com.example.agent.providers.LlmProvider;
+import com.example.agent.rag.SimpleIndexer;
+import com.example.agent.rules.RuleLoaderV2;
+import com.example.agent.rules.RuleV2;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TranslatorAgentTest {
+
+    @Test
+    void translatesCallsWithoutUnknown() throws Exception {
+        Path runtime = Files.createTempDirectory("runtime");
+        RuleLoaderV2 loader = new RuleLoaderV2(runtime);
+        RuleV2 call = new RuleV2();
+        call.id = "call";
+        call.type = "stmt";
+        call.irType = "Call";
+        call.regex = "^\\s*([A-Za-z_][A-Za-z0-9_]*)\\s*\\((.*)\\)\\s*;\\s*$";
+        call.fields = new String[]{"callee", "args"};
+        call.listFields = new String[]{"args"};
+        loader.addOrMerge(call);
+
+        LlmProvider llm = (msgs, t) -> "";
+        SimpleIndexer indexer = new SimpleIndexer();
+        RuleStore store = new RuleStore(Files.createTempDirectory("proc"));
+        TranslatorAgent agent = new TranslatorAgent(llm, indexer, store, loader);
+
+        String src = "createLog('log'); deleteTune('t'); msg('done');";
+        String java = agent.translate(src);
+
+        assertTrue(java.contains("createLog"));
+        assertTrue(java.contains("deleteTune"));
+        assertTrue(java.contains("msg"));
+        assertFalse(java.contains("/* UNKNOWN"));
+    }
+}


### PR DESCRIPTION
## Summary
- add JUnit test ensuring TranslatorAgent handles simple PL/Plus calls without UNKNOWN comments

## Testing
- `./gradlew test` *(fails: Could not resolve org.junit.jupiter:junit-jupiter:5.10.2)*

------
https://chatgpt.com/codex/tasks/task_e_68c3328c03748320ad8fc3e035970da4