### PR TITLE
Separate ELSE blocks in PL/Plus manifest

### DIFF
--- a/spec/plplus_syntax_manifest.json
+++ b/spec/plplus_syntax_manifest.json
@@ -29,6 +29,12 @@
       "strategy": "regex_boundary_keep",
       "regex": "(\\*{1,3}|\\+|-|/|%|\\^|<=|>=|!=|=|<|>)",
       "priority": 8
+    },
+    {
+      "id": "seg_begin_else",
+      "strategy": "regex_after",
+      "regex": "(?i)\\b(?:BEGIN|ELSE)\\b",
+      "priority": 8
     }
   ],
   "blocks": [


### PR DESCRIPTION
## Summary
- ensure `ELSE` and `BEGIN` tokens close the preceding segment so branch statements are isolated

## Testing
- `./gradlew run --args="translate /tmp/plplus_sample.dlx"` *(fails: UnknownHostException ngw.devices.sberbank.ru)*
- `./gradlew test` *(fails: Could not resolve org.junit.jupiter:junit-jupiter:5.10.2)*

------
https://chatgpt.com/codex/tasks/task_e_68c337edad3c8320b062d17383ce6607