### PR TITLE
Handle amp macros with nested parentheses

### DIFF
--- a/spec/plplus_syntax_manifest.json
+++ b/spec/plplus_syntax_manifest.json
@@ -383,8 +383,7 @@
       "priority": 9
     },
     { "id": "rw_amp_macro_strict",
-      "pattern": "&([A-Za-z_][A-Za-z0-9_]*)\\s*\\(([^()]*)\\)",
-      "replace": "$1($2)",
+      "pattern": "&([A-Za-z_][A-Za-z0-9_]*)\\s*\\(",
       "priority": 8
     },
     { "id": "rw_macro_anyprefix_safe",
@@ -413,8 +412,7 @@
       "priority": 9
     },
     { "id": "rw_amp_macro_strict",
-      "pattern": "&([A-Za-z_][A-Za-z0-9_]*)\\s*\\(([^()]*)\\)",
-      "replace": "$1($2)",
+      "pattern": "&([A-Za-z_][A-Za-z0-9_]*)\\s*\\(",
       "priority": 8
     },
     { "id": "rw_macro_anyprefix_safe",
@@ -433,8 +431,7 @@
       "priority": 9
     },
     { "id": "rw_amp_macro_strict",
-      "pattern": "&([A-Za-z_][A-Za-z0-9_]*)\\s*\\(([^()]*)\\)",
-      "replace": "$1($2)",
+      "pattern": "&([A-Za-z_][A-Za-z0-9_]*)\\s*\\(",
       "priority": 6
     },
     { "id": "rw_macro_anyprefix_safe",
@@ -516,8 +513,7 @@
     },
     {
       "id": "rw_amp_macro_strict",
-      "pattern": "&([A-Za-z_][A-Za-z0-9_]*)\\s*\\(([^()]*)\\)",
-      "replace": "$1($2)",
+      "pattern": "&([A-Za-z_][A-Za-z0-9_]*)\\s*\\(",
       "priority": 6
     },
     {

--- a/src/main/java/com/example/agent/rules/RewriteEngine.java
+++ b/src/main/java/com/example/agent/rules/RewriteEngine.java
@@ -7,9 +7,53 @@ public final class RewriteEngine {
     if (s == null) return null;
     String out = s;
     for (RuleV2 r : rewrite) {
+      if ("rw_amp_macro_strict".equals(r.id)) {
+        out = rewriteAmpMacroStrict(out);
+        continue;
+      }
       if (r.pattern == null || r.replace == null) continue;
       try { out = out.replaceAll(r.pattern, r.replace); } catch (Exception ignored) {}
     }
     return out;
+  }
+
+  private String rewriteAmpMacroStrict(String s) {
+    StringBuilder sb = new StringBuilder();
+    int i = 0;
+    while (i < s.length()) {
+      char c = s.charAt(i);
+      if (c == '&' && i + 1 < s.length() &&
+          (Character.isLetter(s.charAt(i + 1)) || s.charAt(i + 1) == '_')) {
+        int j = i + 1;
+        while (j < s.length() &&
+               (Character.isLetterOrDigit(s.charAt(j)) || s.charAt(j) == '_')) {
+          j++;
+        }
+        int k = j;
+        while (k < s.length() && Character.isWhitespace(s.charAt(k))) k++;
+        if (k < s.length() && s.charAt(k) == '(') {
+          int depth = 0;
+          int m = k;
+          while (m < s.length()) {
+            char ch = s.charAt(m);
+            if (ch == '(') depth++;
+            else if (ch == ')') {
+              depth--;
+              if (depth == 0) break;
+            }
+            m++;
+          }
+          if (depth == 0) {
+            sb.append(s, i + 1, k); // name without '&' and spaces
+            sb.append(s, k, m + 1); // full arg list
+            i = m + 1;
+            continue;
+          }
+        }
+      }
+      sb.append(c);
+      i++;
+    }
+    return sb.toString();
   }
 }

--- a/src/test/java/com/example/agent/rules/RewriteEngineTest.java
+++ b/src/test/java/com/example/agent/rules/RewriteEngineTest.java
@@ -1,0 +1,17 @@
+package com.example.agent.rules;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class RewriteEngineTest {
+  @Test
+  void ampMacroHandlesNestedParens() {
+    RuleV2 r = new RuleV2();
+    r.id = "rw_amp_macro_strict";
+    String out = new RewriteEngine().applyAll("&msg(foo(bar))", List.of(r));
+    assertEquals("msg(foo(bar))", out);
+  }
+}


### PR DESCRIPTION
## Summary
- Add custom parser in `RewriteEngine` for `rw_amp_macro_strict` to handle macros with balanced parentheses and strip leading `&`.
- Update manifest to drop fragile regex for amp macros.
- Cover `&msg(foo(bar))` in tests to ensure nested parentheses are preserved.

## Testing
- `./gradlew test` *(fails: Could not resolve org.junit.jupiter:junit-jupiter:5.10.2)*


------
https://chatgpt.com/codex/tasks/task_e_68c337eec89483209941ad245591b284