### PR TITLE
Cache statement rule patterns and refresh

### DIFF
--- a/src/main/java/com/example/agent/rules/BlockEngine.java
+++ b/src/main/java/com/example/agent/rules/BlockEngine.java
@@ -21,13 +21,12 @@ public final class BlockEngine {
     }
   }
 
-  public IR parse(List<String> tokens, List<RuleV2> blockRules, List<RuleV2> stmtRules) {
+  public IR parse(List<String> tokens, List<RuleV2> blockRules, StmtEngine stmt) {
     List<CompBlock> blocks = new ArrayList<>();
     blockRules.stream().sorted((a,b)->Integer.compare(b.priority, a.priority)).forEach(r -> blocks.add(new CompBlock(r)));
     var ir = new IR();
     var stack = new ArrayDeque<Frame>();
     List<IR.Node> current = ir.nodes;
-    var stmt = new StmtEngine();
 
     for (String t : tokens) {
       boolean handled = false;
@@ -68,7 +67,7 @@ public final class BlockEngine {
       if (handled) continue;
 
       // STMT
-      IR.Node n = stmt.match(t, stmtRules);
+      IR.Node n = stmt.match(t);
       current.add(n);
     }
 

--- a/src/main/java/com/example/agent/rules/StmtEngine.java
+++ b/src/main/java/com/example/agent/rules/StmtEngine.java
@@ -18,15 +18,29 @@ public final class StmtEngine {
         }
     }
 
-    public IR.Node match(String line, List<RuleV2> stmtRules) {
-        List<Compiled> compiled = new ArrayList<>();
-        for (RuleV2 r : stmtRules) {
-            if (r.regex == null) continue;
-            try {
-                compiled.add(new Compiled(r));
-            } catch (Exception ignored) {
+    private List<Compiled> compiled = new ArrayList<>();
+
+    public StmtEngine() {}
+
+    public StmtEngine(List<RuleV2> stmtRules) {
+        refresh(stmtRules);
+    }
+
+    public void refresh(List<RuleV2> stmtRules) {
+        List<Compiled> c = new ArrayList<>();
+        if (stmtRules != null) {
+            for (RuleV2 r : stmtRules) {
+                if (r.regex == null) continue;
+                try {
+                    c.add(new Compiled(r));
+                } catch (Exception ignored) {
+                }
             }
         }
+        this.compiled = c;
+    }
+
+    public IR.Node match(String line) {
         for (Compiled cr : compiled) {
             Matcher m = cr.p.matcher(line);
             if (m.matches()) {

--- a/src/test/java/com/example/agent/AmpMacroRewriteTest.java
+++ b/src/test/java/com/example/agent/AmpMacroRewriteTest.java
@@ -33,8 +33,8 @@ public class AmpMacroRewriteTest {
         sc.irType = "Call";
         sc.regex = "^\\s*([A-Za-z_][A-Za-z0-9_]*)\\s*\\((.*)\\)\\s*;?\\s*$";
 
-        StmtEngine stmt = new StmtEngine();
-        IR.Node n = stmt.match(normalized, List.of(sc));
+        StmtEngine stmt = new StmtEngine(List.of(sc));
+        IR.Node n = stmt.match(normalized);
         assertTrue(n instanceof IR.Call, "Should parse as Call");
         assertEquals("msg", ((IR.Call) n).callee);
     }

--- a/src/test/java/com/example/agent/BeginBlockTest.java
+++ b/src/test/java/com/example/agent/BeginBlockTest.java
@@ -5,6 +5,7 @@ import com.example.agent.model.ir.IR;
 import com.example.agent.rules.BlockEngine;
 import com.example.agent.rules.RuleLoaderV2;
 import com.example.agent.rules.SegmentEngine;
+import com.example.agent.rules.StmtEngine;
 import com.example.agent.translate.IRToJava;
 import org.junit.jupiter.api.Test;
 
@@ -25,12 +26,14 @@ public class BeginBlockTest {
         List<String> tokens = new SegmentEngine().segment(src, loader.ofType("segment"));
         assertEquals(List.of("BEGIN", "P_ROLLBACK := 1;", "END;"), tokens);
 
-        var ir = new BlockEngine().parse(tokens, loader.ofType("block"), loader.ofType("stmt"));
+        StmtEngine stmt = new StmtEngine(loader.ofType("stmt"));
+        var ir = new BlockEngine().parse(tokens, loader.ofType("block"), stmt);
         assertFalse(ir.nodes.isEmpty());
         assertTrue(ir.nodes.get(0) instanceof IR.Block);
         IR.Block blk = (IR.Block) ir.nodes.get(0);
         assertEquals(1, blk.body.size());
         assertTrue(blk.body.get(0) instanceof IR.Assign);
+        assertTrue(blk.body.stream().noneMatch(n -> n instanceof IR.UnknownNode));
 
         String java = new IRToJava().generate(ir, "Demo");
         String norm = java.replace("\r", "");

--- a/src/test/java/com/example/agent/StmtEngineCacheTest.java
+++ b/src/test/java/com/example/agent/StmtEngineCacheTest.java
@@ -1,0 +1,42 @@
+package com.example.agent;
+
+import com.example.agent.model.ir.IR;
+import com.example.agent.rules.RuleV2;
+import com.example.agent.rules.StmtEngine;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class StmtEngineCacheTest {
+    @Test
+    void cachesAndRefreshes() {
+        RuleV2 assign = new RuleV2();
+        assign.id = "assign";
+        assign.type = "stmt";
+        assign.irType = "Assign";
+        assign.regex = "^\\s*([A-Za-z_][A-Za-z0-9_]*)\\s*:=\\s*(.*);?\\s*$";
+
+        RuleV2 call = new RuleV2();
+        call.id = "call";
+        call.type = "stmt";
+        call.irType = "Call";
+        call.regex = "^\\s*([A-Za-z_][A-Za-z0-9_]*)\\s*\\((.*)\\)\\s*;?\\s*$";
+
+        StmtEngine engine = new StmtEngine(List.of(assign, call));
+
+        IR.Node n1 = engine.match("X := 1;");
+        assertTrue(n1 instanceof IR.Assign);
+        IR.Node n2 = engine.match("foo(bar);");
+        assertTrue(n2 instanceof IR.Call);
+        assertFalse(n1 instanceof IR.UnknownNode);
+        assertFalse(n2 instanceof IR.UnknownNode);
+
+        engine.refresh(List.of(call));
+        IR.Node afterRefresh = engine.match("X := 1;");
+        assertTrue(afterRefresh instanceof IR.UnknownNode);
+        IR.Node callAgain = engine.match("foo(bar);");
+        assertTrue(callAgain instanceof IR.Call);
+    }
+}


### PR DESCRIPTION
## Summary
- Cache statement rule regex patterns in `StmtEngine` with a refreshable compiled rule list
- Update `BlockEngine` and callers to reuse a shared `StmtEngine`
- Add tests covering caching behaviour and verify no extra `UnknownNode` instances

## Testing
- ⚠️ `./gradlew test` *(dependency resolution failed: Could not resolve org.junit.jupiter:junit-jupiter:5.10.2 (403 Forbidden))*
- ✅ `./gradlew compileJava`

------
https://chatgpt.com/codex/tasks/task_e_68c33c24c8708320a6f7e21e5611a1d8