### PR TITLE
Add collect CLI command for gathering PLP samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ System.out.println(java);
 ./gradlew run --args="learn /path/to/repo .dlx,.dsl,.txt"
 ./gradlew run --args="translate samples/example.dlx"
 ./gradlew run --args="fix path/to/frag.dlx path/to/current.java path/to/feedback.txt"
+./gradlew run --args="collect /path/to/plp/files"
 ```
 
 Для включения подробного логирования команды `learn` установите `log=true` в `gradle.properties`.


### PR DESCRIPTION
## Summary
- add `collect` CLI command to copy `.plp` files from a given path into the repository's `samples` directory
- document the new `collect` command in the README

## Testing
- `./gradlew test` *(fails: Could not resolve org.junit.jupiter:junit-jupiter:5.10.2)*

------
https://chatgpt.com/codex/tasks/task_e_68c33f64025883208165d5db0bfe43dc