### PR TITLE
Handle file processing errors in LearnerV2

### DIFF
--- a/src/main/java/com/example/agent/util/Log.java
+++ b/src/main/java/com/example/agent/util/Log.java
@@ -13,5 +13,20 @@ public final class Log {
             System.out.println(msg);
         }
     }
+
+    /** Logs message and optional stack trace to stderr when logging is enabled. */
+    public static void error(String msg, Throwable t) {
+        if (ENABLED) {
+            System.err.println(msg);
+            if (t != null) {
+                t.printStackTrace(System.err);
+            }
+        }
+    }
+
+    /** Logs message to stderr when logging is enabled. */
+    public static void error(String msg) {
+        error(msg, null);
+    }
 }
 


### PR DESCRIPTION
## Summary
- Wrap file reading and LLM interaction in `LearnerV2.learnFromRepo` with try/catch and log failures
- Add `Log.error` to report errors to stderr

## Testing
- `./gradlew test` *(fails: Could not resolve org.junit.jupiter:junit-jupiter:5.10.2)*

------
https://chatgpt.com/codex/tasks/task_e_68c3411148b883208db76f7347b578d5