### PR TITLE
Handle IF/ELSIF/ELSE boundaries

### DIFF
--- a/src/main/java/com/example/agent/rules/SegmentEngine.java
+++ b/src/main/java/com/example/agent/rules/SegmentEngine.java
@@ -40,13 +40,23 @@ public final class SegmentEngine {
 
     private List<String> splitKeywordBoundaries(List<String> tokens) {
         List<String> out = new ArrayList<>();
-        Pattern kw = Pattern.compile("^(?i)(BEGIN|IF|END)\\b\\s+(.+)$");
+        Pattern simple = Pattern.compile("^(?i)(BEGIN|END|ELSE)\\b\\s+(.+)$");
+        Pattern cond = Pattern.compile("^(?i)(IF|ELSIF)\\b\\s+(.+?)\\s+(?i:THEN)\\b(.*)$", Pattern.DOTALL);
         for (String t : tokens) {
             String trimmed = t.trim();
-            Matcher m = kw.matcher(trimmed);
-            if (m.matches()) {
-                out.add(m.group(1).toUpperCase(Locale.ROOT));
-                String rest = m.group(2).trim();
+            Matcher cm = cond.matcher(trimmed);
+            if (cm.matches()) {
+                String kw = cm.group(1).toUpperCase(Locale.ROOT);
+                String condText = cm.group(2).trim();
+                String after = cm.group(3).trim();
+                out.add(kw + " " + condText + " THEN");
+                if (!after.isEmpty()) out.add(after);
+                continue;
+            }
+            Matcher sm = simple.matcher(trimmed);
+            if (sm.matches()) {
+                out.add(sm.group(1).toUpperCase(Locale.ROOT));
+                String rest = sm.group(2).trim();
                 if (!rest.isEmpty()) out.add(rest);
             } else {
                 out.add(trimmed);

--- a/src/test/java/com/example/agent/IfElseSplitTest.java
+++ b/src/test/java/com/example/agent/IfElseSplitTest.java
@@ -1,0 +1,36 @@
+package com.example.agent;
+
+import com.example.agent.grammar.ManifestDrivenGrammarSeeder;
+import com.example.agent.rules.RuleLoaderV2;
+import com.example.agent.rules.SegmentEngine;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class IfElseSplitTest {
+
+    @Test
+    void ifThenAssignmentSplit() throws Exception {
+        Path runtime = Files.createTempDirectory("runtime");
+        new ManifestDrivenGrammarSeeder(Path.of("spec/plplus_syntax_manifest.json"), runtime).seed();
+        RuleLoaderV2 loader = new RuleLoaderV2(runtime);
+        String src = "IF P_BRANCH IS NULL THEN P_DEPART_GROUP := NULL; END IF;";
+        List<String> tokens = new SegmentEngine().segment(src, loader.ofType("segment"));
+        assertEquals("IF P_BRANCH IS NULL THEN", tokens.get(0));
+        assertEquals("P_DEPART_GROUP := NULL;", tokens.get(1));
+    }
+
+    @Test
+    void elseAssignmentSplit() throws Exception {
+        Path runtime = Files.createTempDirectory("runtime");
+        new ManifestDrivenGrammarSeeder(Path.of("spec/plplus_syntax_manifest.json"), runtime).seed();
+        RuleLoaderV2 loader = new RuleLoaderV2(runtime);
+        String src = "ELSE P_DEPART_GROUP := NULL;";
+        List<String> tokens = new SegmentEngine().segment(src, loader.ofType("segment"));
+        assertEquals(List.of("ELSE", "P_DEPART_GROUP := NULL;"), tokens);
+    }
+}


### PR DESCRIPTION
## Summary
- refine keyword splitting to keep IF/ELSIF/ELSE clauses intact
- add regression tests for IF...THEN and ELSE assignments

## Testing
- `./gradlew test` *(fails: Could not resolve junit-jupiter due to 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c3494a656483209aff78e1783d0aa8