### PR TITLE
Add IR pragma handling for PRAGMA ERROR

### DIFF
--- a/src/main/java/com/example/agent/model/ir/IR.java
+++ b/src/main/java/com/example/agent/model/ir/IR.java
@@ -6,7 +6,7 @@ import java.util.List;
 public class IR {
     public final List<Node> nodes = new ArrayList<>();
 
-    public sealed interface Node permits Assign, Call, If, Loop, Decl, Block, UnknownNode {}
+    public sealed interface Node permits Assign, Call, If, Loop, Decl, Block, Pragma, UnknownNode {}
 
     public static final class Assign implements Node {
         public final String name;
@@ -44,6 +44,15 @@ public class IR {
         public final String name;
         public final String type;
         public Decl(String name, String type) { this.name = name; this.type = type; }
+    }
+
+    public static final class Pragma implements Node {
+        public final String name;
+        public final String args;
+        public Pragma(String name, String args) {
+            this.name = name;
+            this.args = args;
+        }
     }
 
     public static final class UnknownNode implements Node {

--- a/src/main/java/com/example/agent/translate/IRToJava.java
+++ b/src/main/java/com/example/agent/translate/IRToJava.java
@@ -77,6 +77,18 @@ public class IRToJava {
             sb.append(ind).append("}");
             return sb.toString();
         }
+        if (n instanceof IR.Pragma p) {
+            String name = p.name == null ? "" : p.name.trim();
+            String args = p.args == null ? "" : p.args.trim();
+            if (name.equalsIgnoreCase("ERROR")) {
+                if (args.startsWith("(") && args.endsWith(")")) {
+                    args = args.substring(1, args.length() - 1);
+                }
+                return ind + "throw new RuntimeException(" + args + ");";
+            }
+            String commentArgs = args.isBlank() ? "" : " " + escape(args);
+            return ind + "/* PRAGMA " + name + commentArgs + " */";
+        }
         if (n instanceof IR.UnknownNode u) {
             return ind + "/* UNKNOWN: " + escape(u.raw) + " */";
         }

--- a/src/test/java/com/example/agent/PragmaErrorTest.java
+++ b/src/test/java/com/example/agent/PragmaErrorTest.java
@@ -1,0 +1,34 @@
+package com.example.agent;
+
+import com.example.agent.grammar.ManifestDrivenGrammarSeeder;
+import com.example.agent.model.ir.IR;
+import com.example.agent.rules.BlockEngine;
+import com.example.agent.rules.RuleLoaderV2;
+import com.example.agent.rules.SegmentEngine;
+import com.example.agent.rules.StmtEngine;
+import com.example.agent.translate.IRToJava;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class PragmaErrorTest {
+    @Test
+    void pragmaErrorTranslatesToThrow() throws Exception {
+        Path runtime = Files.createTempDirectory("runtime");
+        new ManifestDrivenGrammarSeeder(Path.of("spec/plplus_syntax_manifest.json"), runtime).seed();
+        RuleLoaderV2 loader = new RuleLoaderV2(runtime);
+        String src = "PRAGMA ERROR('msg');";
+        List<String> tokens = new SegmentEngine().segment(src, loader.ofType("segment"));
+        StmtEngine stmt = new StmtEngine(loader.ofType("stmt"));
+        IR ir = new BlockEngine().parse(tokens, loader.ofType("block"), stmt);
+        assertFalse(ir.nodes.isEmpty());
+        assertTrue(ir.nodes.get(0) instanceof IR.Pragma);
+        String java = new IRToJava().generate(ir, "Demo");
+        assertTrue(java.contains("throw new RuntimeException('msg');"));
+        assertFalse(java.contains("UNKNOWN"));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `IR.Pragma` node with name and args fields
- Generate `throw new RuntimeException` for `PRAGMA ERROR` and a pragma comment otherwise
- Test that `PRAGMA ERROR('msg')` translates to a throw without UNKNOWN comments

## Testing
- `./gradlew test` *(fails: Could not resolve org.junit.jupiter:junit-jupiter:5.10.2)*

------
https://chatgpt.com/codex/tasks/task_e_68c3494aa8e88320a90e8ed39fa76a71