### PR TITLE
Handle trailing text for block keywords

### DIFF
--- a/src/main/java/com/example/agent/rules/BlockEngine.java
+++ b/src/main/java/com/example/agent/rules/BlockEngine.java
@@ -28,7 +28,9 @@ public final class BlockEngine {
     var stack = new ArrayDeque<Frame>();
     List<IR.Node> current = ir.nodes;
 
-    for (String t : tokens) {
+    Deque<String> queue = new ArrayDeque<>(tokens);
+    while (!queue.isEmpty()) {
+      String t = queue.removeFirst();
       boolean handled = false;
 
       // CLOSE
@@ -42,9 +44,12 @@ public final class BlockEngine {
         } else {
           // MIDDLE
           for (Pattern mid : top.b.middle) {
-            if (mid.matcher(t).matches()) {
+            Matcher mm = mid.matcher(t);
+            if (mm.lookingAt()) {
               top.switchToElseLike();
               current = top.current();
+              String rest = t.substring(mm.end()).trim();
+              if (!rest.isEmpty()) queue.addFirst(rest);
               handled = true; break;
             }
           }
@@ -56,10 +61,12 @@ public final class BlockEngine {
       for (CompBlock b : blocks) {
         if (b.open != null) {
           Matcher m = b.open.matcher(t);
-          if (m.matches()) {
+          if (m.lookingAt()) {
             Frame f = new Frame(b, instantiateIR(b.r, m));
             stack.push(f);
             current = f.current();
+            String rest = t.substring(m.end()).trim();
+            if (!rest.isEmpty()) queue.addFirst(rest);
             handled = true; break;
           }
         }

--- a/src/test/java/com/example/agent/IfElseBlockTest.java
+++ b/src/test/java/com/example/agent/IfElseBlockTest.java
@@ -1,0 +1,51 @@
+package com.example.agent;
+
+import com.example.agent.grammar.ManifestDrivenGrammarSeeder;
+import com.example.agent.model.ir.IR;
+import com.example.agent.rules.BlockEngine;
+import com.example.agent.rules.RuleLoaderV2;
+import com.example.agent.rules.SegmentEngine;
+import com.example.agent.rules.StmtEngine;
+import com.example.agent.translate.IRToJava;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Verifies ELSE branch statements are parsed correctly. */
+public class IfElseBlockTest {
+
+    @Test
+    void elseAssignmentIsParsed() throws Exception {
+        Path runtime = Files.createTempDirectory("runtime");
+        new ManifestDrivenGrammarSeeder(Path.of("spec/plplus_syntax_manifest.json"), runtime).seed();
+        RuleLoaderV2 loader = new RuleLoaderV2(runtime);
+
+        String src = "IF TRUE THEN P_DEPART_GROUP := 1; ELSE P_DEPART_GROUP := NULL; END IF;";
+        List<String> tokens = new SegmentEngine().segment(src, loader.ofType("segment"));
+
+        StmtEngine stmt = new StmtEngine(loader.ofType("stmt"));
+        var ir = new BlockEngine().parse(tokens, loader.ofType("block"), stmt);
+
+        assertEquals(1, ir.nodes.size());
+        assertTrue(ir.nodes.get(0) instanceof IR.If);
+        IR.If ifNode = (IR.If) ir.nodes.get(0);
+
+        assertEquals(1, ifNode.elseBody.size());
+        assertTrue(ifNode.elseBody.get(0) instanceof IR.Assign);
+        IR.Assign assign = (IR.Assign) ifNode.elseBody.get(0);
+        assertEquals("P_DEPART_GROUP", assign.name);
+        assertEquals("NULL", assign.expr);
+
+        // ensure no UNKNOWN nodes anywhere
+        assertTrue(ifNode.thenBody.stream().noneMatch(n -> n instanceof IR.UnknownNode));
+        assertTrue(ifNode.elseBody.stream().noneMatch(n -> n instanceof IR.UnknownNode));
+
+        String java = new IRToJava().generate(ir, "Demo");
+        assertFalse(java.contains("UNKNOWN"));
+    }
+}
+


### PR DESCRIPTION
## Summary
- Allow block parser to match open/middle keywords with trailing text by using `lookingAt` and pushing leftover back to the token stream
- Add regression test ensuring `ELSE P_DEPART_GROUP := NULL;` is parsed into the else-branch without UNKNOWN nodes

## Testing
- `./gradlew test` *(fails: Could not resolve org.junit.jupiter:junit-jupiter:5.10.2)*


------
https://chatgpt.com/codex/tasks/task_e_68c3494ac888832080fc11f34e8f8f0a