### PR TITLE
Support configurable keyword boundary pairs

### DIFF
--- a/spec/plplus_syntax_manifest.json
+++ b/spec/plplus_syntax_manifest.json
@@ -37,6 +37,12 @@
       "priority": 8
     }
   ],
+  "boundaries": [
+    { "id": "kw_begin_end", "open": "BEGIN", "close": "END" },
+    { "id": "kw_if", "open": "IF", "close": "END IF" },
+    { "id": "kw_case", "open": "CASE", "close": "END CASE" },
+    { "id": "kw_loop", "open": "LOOP", "close": "END LOOP" }
+  ],
   "blocks": [
     {
       "id": "blk_begin_end",

--- a/src/main/java/com/example/agent/grammar/ManifestDrivenGrammarSeeder.java
+++ b/src/main/java/com/example/agent/grammar/ManifestDrivenGrammarSeeder.java
@@ -44,7 +44,17 @@ public class ManifestDrivenGrammarSeeder {
             add(r, dedup, rules);
         }
 
-        // 2) blocks
+        // 2) keyword boundaries
+        for (var kb : spec.withArray("boundaries")) {
+            RuleV2 r = new RuleV2();
+            r.id = kb.path("id").asText();
+            r.type = "boundary";
+            r.open = kb.path("open").asText();
+            r.close = kb.path("close").asText();
+            add(r, dedup, rules);
+        }
+
+        // 3) blocks
         for (var blk : spec.withArray("blocks")) {
             RuleV2 r = new RuleV2();
             r.id = blk.path("id").asText();
@@ -61,7 +71,7 @@ public class ManifestDrivenGrammarSeeder {
             add(r, dedup, rules);
         }
 
-        // 3) statements
+        // 4) statements
         for (var st : spec.withArray("statements")) {
             RuleV2 r = new RuleV2();
             r.id = st.path("id").asText();
@@ -82,7 +92,7 @@ public class ManifestDrivenGrammarSeeder {
             add(r, dedup, rules);
         }
 
-        // 4) rewrites
+        // 5) rewrites
         for (var rw : spec.withArray("rewrites")) {
             RuleV2 r = new RuleV2();
             r.id = rw.path("id").asText();

--- a/src/main/java/com/example/agent/rules/RuleLoaderV2.java
+++ b/src/main/java/com/example/agent/rules/RuleLoaderV2.java
@@ -6,6 +6,8 @@ import java.io.*;
 import java.nio.file.*;
 import java.util.*;
 
+import static java.util.Locale.ROOT;
+
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.StandardOpenOption.CREATE;
 import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
@@ -58,6 +60,25 @@ public class RuleLoaderV2 {
     }
     Files.move(tmp, rulesFile, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
     System.out.println("[SAVE] wrote " + rules.size() + " rules to " + rulesFile.toAbsolutePath());
+  }
+
+  public static class KeywordBoundary {
+    public final String open;
+    public final String close;
+    public KeywordBoundary(String open, String close) {
+      this.open = open == null ? null : open.toUpperCase(ROOT);
+      this.close = close == null ? null : close.toUpperCase(ROOT);
+    }
+  }
+
+  public List<KeywordBoundary> keywordBoundaries() {
+    List<KeywordBoundary> out = new ArrayList<>();
+    for (RuleV2 r : rules) {
+      if ("boundary".equalsIgnoreCase(r.type)) {
+        out.add(new KeywordBoundary(r.open, r.close));
+      }
+    }
+    return out;
   }
 
   private void load() throws IOException {

--- a/src/main/java/com/example/agent/rules/SegmentEngine.java
+++ b/src/main/java/com/example/agent/rules/SegmentEngine.java
@@ -9,7 +9,7 @@ import java.util.regex.Pattern;
  */
 public final class SegmentEngine {
 
-    public List<String> segment(String src, List<RuleV2> segmentRules) {
+    public List<String> segment(String src, List<RuleV2> segmentRules, List<RuleLoaderV2.KeywordBoundary> boundaries) {
         List<String> tokens = new ArrayList<>();
         tokens.add(src);
         for (RuleV2 r : segmentRules) {
@@ -33,24 +33,47 @@ public final class SegmentEngine {
             }
             tokens = next;
         }
-        tokens = splitKeywordBoundaries(tokens);
+        tokens = splitKeywordBoundaries(tokens, boundaries);
         if (tokens.isEmpty()) return splitOutsideQuotesAndParens(src, Pattern.compile(";"));
         return tokens;
     }
 
-    private List<String> splitKeywordBoundaries(List<String> tokens) {
+    private List<String> splitKeywordBoundaries(List<String> tokens, List<RuleLoaderV2.KeywordBoundary> boundaries) {
+        Set<String> openSplit = new HashSet<>();
+        Set<String> closers = new HashSet<>();
+        for (RuleLoaderV2.KeywordBoundary kb : boundaries) {
+            if (kb.close != null) closers.add(kb.close);
+            if (kb.open != null && kb.close != null && "END".equalsIgnoreCase(kb.close)) {
+                openSplit.add(kb.open);
+            }
+        }
         List<String> out = new ArrayList<>();
-        Pattern kw = Pattern.compile("^(?i)(BEGIN|IF|END)\\b\\s+(.+)$");
         for (String t : tokens) {
             String trimmed = t.trim();
-            Matcher m = kw.matcher(trimmed);
-            if (m.matches()) {
-                out.add(m.group(1).toUpperCase(Locale.ROOT));
-                String rest = m.group(2).trim();
-                if (!rest.isEmpty()) out.add(rest);
-            } else {
-                out.add(trimmed);
+            String upper = trimmed.toUpperCase(Locale.ROOT);
+            boolean handled = false;
+
+            for (String kw : openSplit) {
+                if (upper.startsWith(kw + " ")) {
+                    out.add(kw);
+                    String rest = trimmed.substring(kw.length()).trim();
+                    if (!rest.isEmpty()) out.add(rest);
+                    handled = true;
+                    break;
+                }
             }
+            if (handled) continue;
+
+            for (String kw : closers) {
+                if (upper.startsWith(kw + " ")) {
+                    out.add(kw);
+                    String rest = trimmed.substring(kw.length()).trim();
+                    if (!rest.isEmpty()) out.add(rest);
+                    handled = true;
+                    break;
+                }
+            }
+            if (!handled) out.add(trimmed);
         }
         return out;
     }

--- a/src/main/java/com/example/agent/translate/TranslatorAgent.java
+++ b/src/main/java/com/example/agent/translate/TranslatorAgent.java
@@ -30,7 +30,7 @@ public class TranslatorAgent {
     indexer.addDocument(source);
 
     // 1) Segment
-    var seg = new SegmentEngine().segment(source, rules.ofType("segment"));
+    var seg = new SegmentEngine().segment(source, rules.ofType("segment"), rules.keywordBoundaries());
 
     // 2) Blocks + statements
     stmtEngine.refresh(rules.ofType("stmt"));

--- a/src/test/java/com/example/agent/BeginBlockTest.java
+++ b/src/test/java/com/example/agent/BeginBlockTest.java
@@ -23,7 +23,7 @@ public class BeginBlockTest {
         new ManifestDrivenGrammarSeeder(Path.of("spec/plplus_syntax_manifest.json"), runtime).seed();
         RuleLoaderV2 loader = new RuleLoaderV2(runtime);
         String src = "BEGIN\nP_ROLLBACK := 1;\nEND;";
-        List<String> tokens = new SegmentEngine().segment(src, loader.ofType("segment"));
+        List<String> tokens = new SegmentEngine().segment(src, loader.ofType("segment"), loader.keywordBoundaries());
         assertEquals(List.of("BEGIN", "P_ROLLBACK := 1;", "END;"), tokens);
 
         StmtEngine stmt = new StmtEngine(loader.ofType("stmt"));
@@ -47,8 +47,18 @@ public class BeginBlockTest {
         new ManifestDrivenGrammarSeeder(Path.of("spec/plplus_syntax_manifest.json"), runtime).seed();
         RuleLoaderV2 loader = new RuleLoaderV2(runtime);
         String src = "BEGIN P_ROLLBACK := 1; END;";
-        List<String> tokens = new SegmentEngine().segment(src, loader.ofType("segment"));
+        List<String> tokens = new SegmentEngine().segment(src, loader.ofType("segment"), loader.keywordBoundaries());
         assertEquals(List.of("BEGIN", "P_ROLLBACK := 1;", "END;"), tokens);
+    }
+
+    @Test
+    void handlesMultiWordTerminators() throws Exception {
+        Path runtime = Files.createTempDirectory("runtime");
+        new ManifestDrivenGrammarSeeder(Path.of("spec/plplus_syntax_manifest.json"), runtime).seed();
+        RuleLoaderV2 loader = new RuleLoaderV2(runtime);
+        String src = "BEGIN NULL; END IF; END CASE; END LOOP;";
+        List<String> tokens = new SegmentEngine().segment(src, loader.ofType("segment"), loader.keywordBoundaries());
+        assertEquals(List.of("BEGIN", "NULL;", "END IF;", "END CASE;", "END LOOP;"), tokens);
     }
 }
 


### PR DESCRIPTION
## Summary
- Read keyword boundary pairs from spec and seed them as `boundary` rules
- Expose keyword boundaries via `RuleLoaderV2` and use them in `SegmentEngine` to split tokens
- Verify multi-word terminators like `END IF;`, `END CASE;`, `END LOOP;` in tests

## Testing
- `./gradlew test` *(fails: Could not resolve org.junit.jupiter:junit-jupiter:5.10.2, status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c34f04686c832081234be256e2ec06