### PR TITLE
Handle inline block keywords

### DIFF
--- a/src/main/java/com/example/agent/rules/BlockEngine.java
+++ b/src/main/java/com/example/agent/rules/BlockEngine.java
@@ -28,7 +28,10 @@ public final class BlockEngine {
     var stack = new ArrayDeque<Frame>();
     List<IR.Node> current = ir.nodes;
 
-    for (String t : tokens) {
+    List<String> stream = new ArrayList<>(tokens);
+    ListIterator<String> it = stream.listIterator();
+    while (it.hasNext()) {
+      String t = it.next();
       boolean handled = false;
 
       // CLOSE
@@ -42,9 +45,12 @@ public final class BlockEngine {
         } else {
           // MIDDLE
           for (Pattern mid : top.b.middle) {
-            if (mid.matcher(t).matches()) {
+            Matcher mm = mid.matcher(t);
+            if (mm.lookingAt()) {
               top.switchToElseLike();
               current = top.current();
+              String rem = t.substring(mm.end()).trim();
+              if (!rem.isEmpty()) it.add(rem);
               handled = true; break;
             }
           }
@@ -56,10 +62,12 @@ public final class BlockEngine {
       for (CompBlock b : blocks) {
         if (b.open != null) {
           Matcher m = b.open.matcher(t);
-          if (m.matches()) {
+          if (m.lookingAt()) {
             Frame f = new Frame(b, instantiateIR(b.r, m));
             stack.push(f);
             current = f.current();
+            String rem = t.substring(m.end()).trim();
+            if (!rem.isEmpty()) it.add(rem);
             handled = true; break;
           }
         }

--- a/src/test/java/com/example/agent/IfInlineTest.java
+++ b/src/test/java/com/example/agent/IfInlineTest.java
@@ -1,0 +1,52 @@
+package com.example.agent;
+
+import com.example.agent.grammar.ManifestDrivenGrammarSeeder;
+import com.example.agent.model.ir.IR;
+import com.example.agent.rules.BlockEngine;
+import com.example.agent.rules.RuleLoaderV2;
+import com.example.agent.rules.SegmentEngine;
+import com.example.agent.rules.StmtEngine;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class IfInlineTest {
+
+    @Test
+    void ifThenActionSameLine() throws Exception {
+        Path runtime = Files.createTempDirectory("runtime");
+        new ManifestDrivenGrammarSeeder(Path.of("spec/plplus_syntax_manifest.json"), runtime).seed();
+        RuleLoaderV2 loader = new RuleLoaderV2(runtime);
+        String src = "IF TRUE THEN P_A := 1; END IF;";
+        List<String> tokens = new SegmentEngine().segment(src, loader.ofType("segment"));
+        StmtEngine stmt = new StmtEngine(loader.ofType("stmt"));
+        var ir = new BlockEngine().parse(tokens, loader.ofType("block"), stmt);
+        assertFalse(ir.nodes.isEmpty());
+        assertTrue(ir.nodes.get(0) instanceof IR.If);
+        IR.If ifNode = (IR.If) ir.nodes.get(0);
+        assertEquals(1, ifNode.thenBody.size());
+        assertTrue(ifNode.thenBody.get(0) instanceof IR.Assign);
+    }
+
+    @Test
+    void elseActionSameLine() throws Exception {
+        Path runtime = Files.createTempDirectory("runtime");
+        new ManifestDrivenGrammarSeeder(Path.of("spec/plplus_syntax_manifest.json"), runtime).seed();
+        RuleLoaderV2 loader = new RuleLoaderV2(runtime);
+        String src = "IF TRUE THEN P_A := 1; ELSE P_A := 2; END IF;";
+        List<String> tokens = new SegmentEngine().segment(src, loader.ofType("segment"));
+        StmtEngine stmt = new StmtEngine(loader.ofType("stmt"));
+        var ir = new BlockEngine().parse(tokens, loader.ofType("block"), stmt);
+        assertFalse(ir.nodes.isEmpty());
+        assertTrue(ir.nodes.get(0) instanceof IR.If);
+        IR.If ifNode = (IR.If) ir.nodes.get(0);
+        assertEquals(1, ifNode.thenBody.size());
+        assertEquals(1, ifNode.elseBody.size());
+        assertTrue(ifNode.elseBody.get(0) instanceof IR.Assign);
+    }
+}
+


### PR DESCRIPTION
## Summary
- Parse block openings and middles with `lookingAt` and push leftover text back for statement parsing
- Add regression tests for inline `IF ... THEN action;` and `ELSE action;` forms

## Testing
- `./gradlew compileJava`
- `./gradlew test` *(fails: Could not resolve org.junit.jupiter:junit-jupiter:5.10.2 (403 Forbidden))*

------
https://chatgpt.com/codex/tasks/task_e_68c34d409e4083208e53b8c810b0b845