### PR TITLE
Prevent generation of empty else and catch blocks

### DIFF
--- a/src/main/java/com/example/agent/translate/IRToJava.java
+++ b/src/main/java/com/example/agent/translate/IRToJava.java
@@ -51,11 +51,14 @@ public class IRToJava {
             for (IR.Node child : i.thenBody) {
                 sb.append(genStmt(child, indent + 1)).append("\n");
             }
-            sb.append(ind).append("} else {\n");
-            for (IR.Node child : i.elseBody) {
-                sb.append(genStmt(child, indent + 1)).append("\n");
-            }
             sb.append(ind).append("}");
+            if (!i.elseBody.isEmpty()) {
+                sb.append(" else {\n");
+                for (IR.Node child : i.elseBody) {
+                    sb.append(genStmt(child, indent + 1)).append("\n");
+                }
+                sb.append(ind).append("}");
+            }
             return sb.toString();
         }
         if (n instanceof IR.Loop l) {
@@ -78,17 +81,23 @@ public class IRToJava {
             return sb.toString();
         }
         if (n instanceof IR.TryCatch tc) {
+            if (tc.tryBody.isEmpty() && tc.catchBody.isEmpty()) {
+                return ind + "/* TODO: missing try-catch logic */";
+            }
             StringBuilder sb = new StringBuilder();
             sb.append(ind).append("try {\n");
             for (IR.Node child : tc.tryBody) {
                 sb.append(genStmt(child, indent + 1)).append("\n");
             }
-            String ex = (tc.exceptionName != null && !tc.exceptionName.isBlank()) ? tc.exceptionName + " e" : "Exception e";
-            sb.append(ind).append("} catch (" + ex + ") {\n");
-            for (IR.Node child : tc.catchBody) {
-                sb.append(genStmt(child, indent + 1)).append("\n");
-            }
             sb.append(ind).append("}");
+            if (!tc.catchBody.isEmpty()) {
+                String ex = (tc.exceptionName != null && !tc.exceptionName.isBlank()) ? tc.exceptionName + " e" : "Exception e";
+                sb.append(" catch (" + ex + ") {\n");
+                for (IR.Node child : tc.catchBody) {
+                    sb.append(genStmt(child, indent + 1)).append("\n");
+                }
+                sb.append(ind).append("}");
+            }
             return sb.toString();
         }
         if (n instanceof IR.UnknownNode u) {


### PR DESCRIPTION
## Summary
- Avoid emitting `else` blocks when no `elseBody` statements are present
- Skip empty `catch` blocks and replace fully empty try/catch with a TODO comment

## Testing
- `./gradlew test` *(fails: Could not resolve org.junit.jupiter due to 403 Forbidden)*
- `./gradlew run --args="translate samples/example.dlx"` *(fails: UnknownHostException ngw.devices.sberbank.ru)*
- `jshell --class-path build/classes/java/main` (generated Java without empty `else`/`catch` blocks)


------
https://chatgpt.com/codex/tasks/task_e_68c3c2536aa083208f593daaaebd956d