### PR TITLE
Preserve IR node bodies during block finalization

### DIFF
--- a/src/main/java/com/example/agent/rules/BlockEngine.java
+++ b/src/main/java/com/example/agent/rules/BlockEngine.java
@@ -99,12 +99,34 @@ public final class BlockEngine {
     void switchToElseLike(){ this.elseLike = true; }
     List<IR.Node> current(){ return elseLike ? elseBody : thenBody; }
     IR.Node finalizeNode() {
+      var cls = node.getClass();
       try {
-        var cls = node.getClass();
-        try { var thenF = cls.getField("thenBody"); thenF.set(node, thenBody); } catch (NoSuchFieldException ignore){}
-        try { var elseF = cls.getField("elseBody"); elseF.set(node, elseBody); } catch (NoSuchFieldException ignore){}
-        try { var bodyF = cls.getField("body"); bodyF.set(node, thenBody); } catch (NoSuchFieldException ignore){}
-      } catch (Throwable ignored) {}
+        var thenF = cls.getField("thenBody");
+        @SuppressWarnings("unchecked")
+        var list = (List<IR.Node>) thenF.get(node);
+        list.addAll(thenBody);
+      } catch (NoSuchFieldException ignore) {
+      } catch (IllegalAccessException e) {
+        throw new RuntimeException(e);
+      }
+      try {
+        var elseF = cls.getField("elseBody");
+        @SuppressWarnings("unchecked")
+        var list = (List<IR.Node>) elseF.get(node);
+        list.addAll(elseBody);
+      } catch (NoSuchFieldException ignore) {
+      } catch (IllegalAccessException e) {
+        throw new RuntimeException(e);
+      }
+      try {
+        var bodyF = cls.getField("body");
+        @SuppressWarnings("unchecked")
+        var list = (List<IR.Node>) bodyF.get(node);
+        list.addAll(thenBody);
+      } catch (NoSuchFieldException ignore) {
+      } catch (IllegalAccessException e) {
+        throw new RuntimeException(e);
+      }
       return node;
     }
   }


### PR DESCRIPTION
## Summary
- Build block bodies by appending to existing IR node lists instead of replacing them
- Switch to reflection-based `addAll` to retain accumulated statements

## Testing
- `./gradlew test` *(fails: Could not resolve org.junit.jupiter:junit-jupiter:5.10.2. Received status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c3c5316cf08320af8a4f27428d3c2b