### PR TITLE
feat: support namespaced calls

### DIFF
--- a/src/main/java/com/example/agent/bootstrap/Improver.java
+++ b/src/main/java/com/example/agent/bootstrap/Improver.java
@@ -25,7 +25,7 @@ public class Improver {
     public void refineRules(String dialectSnippet, String javaResult, String diagnosticsOrFeedback) throws IOException {
         String prompt = "На основе пары (диалект -> Java) предложи улучшения правил распознавания в формате JSONL. " +
                 "Строгие поля: id, irType, regex, fields:[...], listFields:[...] (опц.), javaTemplate (опц.). " +
-                "Используй IR-ноды: Assign(name,expr), Call(callee,args), Decl(name,type), If(cond), Loop(header). " +
+                "Используй IR-ноды: Assign(name,expr), Call(callee,ns,args), Decl(name,type), If(cond), Loop(header). " +
                 "Не дублируй существующие правила, обобщи, стабилизируй regex.\n\n" +
                 "Диалект:\n" + dialectSnippet + "\n\nJava:\n" + javaResult + "\n\nЗамечания/диагностика:\n" + diagnosticsOrFeedback +
                 "\n\nВерни только JSONL.";

--- a/src/main/java/com/example/agent/bootstrap/Learner.java
+++ b/src/main/java/com/example/agent/bootstrap/Learner.java
@@ -91,8 +91,8 @@ public class Learner {
         return "Дан фрагмент неизвестного диалекта. Выведи несколько правил распознавания конструкций (присваивание, вызов, объявление, условие, цикл) " +
                 "в формате JSONL. Каждая строка — JSON-объект со строгими полями: " +
                 "{id, irType, regex, fields:[...], listFields:[...] (опционально), javaTemplate (опционально)}. " +
-                "irType должен совпадать с IR-нодой: Assign(name,expr), Call(callee,args), Decl(name,type), If(cond), Loop(header). " +
-                "fields — порядок аргументов конструктора (например Assign → [\"name\",\"expr\"], Call → [\"callee\",\"args\"]). " +
+                "irType должен совпадать с IR-нодой: Assign(name,expr), Call(callee,ns,args), Decl(name,type), If(cond), Loop(header). " +
+                "fields — порядок аргументов конструктора (например Assign → [\"name\",\"expr\"], Call → [\"callee\",\"ns\",\"args\"]). " +
                 "Если поле — список аргументов (CSV), добавь его имя в listFields (например для Call: [\"args\"]).\n\n" +
                 "Пример (не копируй буквально):\n" +
                 "{\"id\":\"assign1\",\"irType\":\"Assign\",\"regex\":\"^\\\\s*([A-Za-z_][A-Za-z0-9_]*)\\\\s*:=\\\\s*(.+);\\\\s*$\",\"fields\":[\"name\",\"expr\"]}\n" +

--- a/src/main/java/com/example/agent/model/ir/IR.java
+++ b/src/main/java/com/example/agent/model/ir/IR.java
@@ -16,9 +16,12 @@ public class IR {
 
     public static final class Call implements Node {
         public final String callee;
+        public final String ns;
         public final List<String> args;
-        public Call(String callee, List<String> args) {
-            this.callee = callee; this.args = args;
+        public Call(String callee, String ns, List<String> args) {
+            this.callee = callee;
+            this.ns = ns;
+            this.args = args;
         }
     }
 

--- a/src/main/java/com/example/agent/rules/StmtEngine.java
+++ b/src/main/java/com/example/agent/rules/StmtEngine.java
@@ -68,6 +68,17 @@ public final class StmtEngine {
                     args[i] = val;
                 }
             }
+            if ("Call".equals(r.irType) && args.length == 3) {
+                Object first = args[0];
+                Object second = args[1];
+                if (second == null || String.valueOf(second).isBlank()) {
+                    args[0] = first;
+                    args[1] = null;
+                } else {
+                    args[0] = second;
+                    args[1] = first;
+                }
+            }
             return (IR.Node) ctor.newInstance(args);
         } catch (Throwable t) {
             return new IR.UnknownNode(m.group(0));

--- a/src/main/java/com/example/agent/translate/IRToJava.java
+++ b/src/main/java/com/example/agent/translate/IRToJava.java
@@ -31,7 +31,8 @@ public class IRToJava {
         if (n instanceof IR.Call c) {
             if ("msg".equals(c.callee)) needMsg = true;
             String args = String.join(", ", c.args);
-            return ind + c.callee + "(" + args + ");";
+            String prefix = (c.ns != null && !c.ns.isBlank()) ? c.ns + "." : "";
+            return ind + prefix + c.callee + "(" + args + ");";
         }
         if (n instanceof IR.Decl d) {
             return ind + d.type + " " + d.name + ";";

--- a/src/test/java/com/example/agent/AmpMacroRewriteTest.java
+++ b/src/test/java/com/example/agent/AmpMacroRewriteTest.java
@@ -31,11 +31,13 @@ public class AmpMacroRewriteTest {
         sc.id = "stmt_call";
         sc.type = "stmt";
         sc.irType = "Call";
-        sc.regex = "^\\s*([A-Za-z_][A-Za-z0-9_]*)\\s*\\((.*)\\)\\s*;?\\s*$";
+        sc.regex = "^\\s*([A-Za-z_][A-Za-z0-9_]*)(?:\\s*(?:\\.|::)\\s*([A-Za-z_][A-Za-z0-9_]*))?\\s*\\((.*)\\)\\s*;?\\s*$";
 
         StmtEngine stmt = new StmtEngine(List.of(sc));
         IR.Node n = stmt.match(normalized);
         assertTrue(n instanceof IR.Call, "Should parse as Call");
-        assertEquals("msg", ((IR.Call) n).callee);
+        IR.Call call = (IR.Call) n;
+        assertEquals("msg", call.callee);
+        assertNull(call.ns);
     }
 }

--- a/src/test/java/com/example/agent/IRToJavaTest.java
+++ b/src/test/java/com/example/agent/IRToJavaTest.java
@@ -32,19 +32,20 @@ public class IRToJavaTest {
 
         IR.If cond = new IR.If("i == 0");
         IR.Block thenBlock = new IR.Block();
-        thenBlock.body.add(new IR.Call("msg", java.util.List.of("\"zero\"")));
+        thenBlock.body.add(new IR.Call("msg", null, java.util.List.of("\"zero\"")));
         cond.thenBody.add(thenBlock);
         IR.Block elseBlock = new IR.Block();
-        elseBlock.body.add(new IR.Call("msg", java.util.List.of("\"non-zero\"")));
+        elseBlock.body.add(new IR.Call("msg", null, java.util.List.of("\"non-zero\"")));
         cond.elseBody.add(elseBlock);
         root.body.add(cond);
 
         IR.Loop loop = new IR.Loop("i < 2");
         IR.Block loopBody = new IR.Block();
         loopBody.body.add(new IR.Assign("i", "i + 1"));
-        loopBody.body.add(new IR.Call("msg", java.util.List.of("\"iter\"")));
+        loopBody.body.add(new IR.Call("msg", null, java.util.List.of("\"iter\"")));
         loop.body.add(loopBody);
         root.body.add(loop);
+        root.body.add(new IR.Call("createLog", "logger", java.util.List.of("true")));
 
         ir.nodes.add(root);
 
@@ -55,6 +56,7 @@ public class IRToJavaTest {
         assertTrue(java.contains("if (i == 0)"));
         assertTrue(java.contains("while (i < 2)"));
         assertTrue(java.contains("msg("));
+        assertTrue(java.contains("logger.createLog(true);"));
     }
 }
 

--- a/src/test/java/com/example/agent/StmtEngineCacheTest.java
+++ b/src/test/java/com/example/agent/StmtEngineCacheTest.java
@@ -22,21 +22,28 @@ public class StmtEngineCacheTest {
         call.id = "call";
         call.type = "stmt";
         call.irType = "Call";
-        call.regex = "^\\s*([A-Za-z_][A-Za-z0-9_]*)\\s*\\((.*)\\)\\s*;?\\s*$";
+        call.regex = "^\\s*([A-Za-z_][A-Za-z0-9_]*)(?:\\s*(?:\\.|::)\\s*([A-Za-z_][A-Za-z0-9_]*))?\\s*\\((.*)\\)\\s*;?\\s*$";
 
         StmtEngine engine = new StmtEngine(List.of(assign, call));
 
         IR.Node n1 = engine.match("X := 1;");
         assertTrue(n1 instanceof IR.Assign);
-        IR.Node n2 = engine.match("foo(bar);");
+        IR.Node n2 = engine.match("createLog(true);");
         assertTrue(n2 instanceof IR.Call);
+        assertEquals("createLog", ((IR.Call) n2).callee);
+        assertNull(((IR.Call) n2).ns);
+        IR.Node n3 = engine.match("logger.createLog(true);");
+        assertTrue(n3 instanceof IR.Call);
+        IR.Call c3 = (IR.Call) n3;
+        assertEquals("createLog", c3.callee);
+        assertEquals("logger", c3.ns);
         assertFalse(n1 instanceof IR.UnknownNode);
         assertFalse(n2 instanceof IR.UnknownNode);
 
         engine.refresh(List.of(call));
         IR.Node afterRefresh = engine.match("X := 1;");
         assertTrue(afterRefresh instanceof IR.UnknownNode);
-        IR.Node callAgain = engine.match("foo(bar);");
+        IR.Node callAgain = engine.match("createLog(true);");
         assertTrue(callAgain instanceof IR.Call);
     }
 }

--- a/src/test/java/com/example/agent/TranslatorAgentMsgTest.java
+++ b/src/test/java/com/example/agent/TranslatorAgentMsgTest.java
@@ -28,7 +28,7 @@ public class TranslatorAgentMsgTest {
         rule.id = "amp_call";
         rule.type = "stmt";
         rule.irType = "Call";
-        rule.regex = "^&([A-Za-z_][A-Za-z0-9_]*)\\(([^)]*)\\)$";
+        rule.regex = "^&([A-Za-z_][A-Za-z0-9_]*)(?:\\s*(?:\\.|::)\\s*([A-Za-z_][A-Za-z0-9_]*))?\\(([^)]*)\\)$";
         loader.addOrMerge(rule);
 
         LlmProvider llm = new LlmProvider() {

--- a/src/test/java/com/example/agent/translate/TranslatorAgentTest.java
+++ b/src/test/java/com/example/agent/translate/TranslatorAgentTest.java
@@ -22,8 +22,8 @@ public class TranslatorAgentTest {
         call.id = "call";
         call.type = "stmt";
         call.irType = "Call";
-        call.regex = "^\\s*([A-Za-z_][A-Za-z0-9_]*)\\s*\\((.*)\\)\\s*;\\s*$";
-        call.fields = new String[]{"callee", "args"};
+        call.regex = "^\\s*([A-Za-z_][A-Za-z0-9_]*)(?:\\s*(?:\\.|::)\\s*([A-Za-z_][A-Za-z0-9_]*))?\\s*\\((.*)\\)\\s*;\\s*$";
+        call.fields = new String[]{"ns", "callee", "args"};
         call.listFields = new String[]{"args"};
         loader.addOrMerge(call);
 


### PR DESCRIPTION
## Summary
- allow IR.Call to hold an optional namespace
- emit namespace qualifiers in Java generation
- parse namespaced calls in StmtEngine and tests

## Testing
- `./gradlew test` *(fails: Could not resolve org.junit.jupiter:junit-jupiter:5.10.2)*

------
https://chatgpt.com/codex/tasks/task_e_68c3c532fd248320b12ab6987072fcd6